### PR TITLE
feat: Add custom Vim-style keybinds (Space=HardDrop, J/L=Move, K=Rotate)

### DIFF
--- a/tetrs_tui/src/game_input_handlers/crossterm.rs
+++ b/tetrs_tui/src/game_input_handlers/crossterm.rs
@@ -63,6 +63,18 @@ impl CrosstermHandler {
         ])
     }
 
+    pub fn vim_keybinds() -> HashMap<KeyCode, Button> {
+        HashMap::from([
+            (KeyCode::Char('h'), Button::DropSoft),
+            (KeyCode::Char('j'), Button::MoveLeft),
+            (KeyCode::Char('k'), Button::RotateRight),
+            (KeyCode::Char('l'), Button::MoveRight),
+            (KeyCode::Char(' '), Button::DropHard),
+            (KeyCode::Char('c'), Button::HoldPiece),
+            (KeyCode::Char('z'), Button::RotateLeft),
+        ])
+    }
+
     fn spawn_standard(
         run_thread_flag: Arc<AtomicBool>,
         input_sender: Sender<InputSignal>,


### PR DESCRIPTION
This PR adds a "Use Vim Defaults" preset to the "Change Keybinds" menu, improving accessibility for users accustomed to Vim navigation.

Changes:

    Added vim_keybinds function to CrosstermHandler in crossterm.rs.

    Added a "Use Vim Defaults" button in the change_keybinds_menu in terminal_user_interface.rs.

Key Mapping:

    h: Drop Soft

    j: Move Left

    k: Rotate Right

    l: Move Right

    Space: Drop Hard

    c: Hold Piece

    z: Rotate Left

I have tested these changes locally, and they work as expected.