### PR TITLE
feat: Add audio engine with async PC speaker and sox support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo run
 > - **Graphics:** Unicode/ASCII/Elektronika styles, old-terminal-compatible or very modern designs, 10 color palettes, hard drop/piece lock/line clear effects and much more.
 > - **Game keybinds:** to your heart's desire. 
 > - **Gameplay/handling:** Various rotation systems, piece randomizers, adjustable preview, timings (DAS¹, ARR¹, SDF¹, LCD, ARE), IRS/IHS/.. ([¹caveat](#why-do-some-gameplay-preferences-dasarrsdf-or-some-keybinds-ctrlshiftalt-not-work-for-me)).
-> - **Audio:** Optional asynchronous PC speaker (`pcspkr`) audio via `beep` for BGM and gameplay SFX, configurable in-app.
+> - **Audio:** Optional asynchronous BGM/SFX audio via PC speaker (`beep`) with selectable `sox` sound-card fallback, configurable in-app.
 > - **Game mode miscellany:** Regular ('Marathon'), Swift ('40-Lines'), Classic & Master (unlocked after Regular), Puzzle, Cheese, Combo, Custom (select win condition, initial gravity, toggle gravity progress, *cmdline flags:* start board, seed).
 > - **Highscores, replays, statistics, ...** - can be viewed as well as backed up with a simple **savefile**.
 >

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo run
 > - **Graphics:** Unicode/ASCII/Elektronika styles, old-terminal-compatible or very modern designs, 10 color palettes, hard drop/piece lock/line clear effects and much more.
 > - **Game keybinds:** to your heart's desire. 
 > - **Gameplay/handling:** Various rotation systems, piece randomizers, adjustable preview, timings (DAS¹, ARR¹, SDF¹, LCD, ARE), IRS/IHS/.. ([¹caveat](#why-do-some-gameplay-preferences-dasarrsdf-or-some-keybinds-ctrlshiftalt-not-work-for-me)).
-> - **Audio:** Optional asynchronous BGM/SFX audio via PC speaker (`beep`) with selectable sound-card backends for MIDI (`timidity`) or `sox`; Auto prefers `beep -> midi -> sox`, configurable in-app.
+> - **Audio:** Optional asynchronous BGM/SFX audio via PC speaker (`beep`) with selectable `sox` sound-card fallback, configurable in-app.
 > - **Game mode miscellany:** Regular ('Marathon'), Swift ('40-Lines'), Classic & Master (unlocked after Regular), Puzzle, Cheese, Combo, Custom (select win condition, initial gravity, toggle gravity progress, *cmdline flags:* start board, seed).
 > - **Highscores, replays, statistics, ...** - can be viewed as well as backed up with a simple **savefile**.
 >

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cargo run
 > - **Graphics:** Unicode/ASCII/Elektronika styles, old-terminal-compatible or very modern designs, 10 color palettes, hard drop/piece lock/line clear effects and much more.
 > - **Game keybinds:** to your heart's desire. 
 > - **Gameplay/handling:** Various rotation systems, piece randomizers, adjustable preview, timings (DAS¹, ARR¹, SDF¹, LCD, ARE), IRS/IHS/.. ([¹caveat](#why-do-some-gameplay-preferences-dasarrsdf-or-some-keybinds-ctrlshiftalt-not-work-for-me)).
-> - **Audio:** Optional asynchronous BGM/SFX audio via PC speaker (`beep`) with selectable `sox` sound-card fallback, configurable in-app.
+> - **Audio:** Optional asynchronous BGM/SFX audio via PC speaker (`beep`) with selectable sound-card backends for MIDI (`timidity`) or `sox`; Auto prefers `beep -> midi -> sox`, configurable in-app.
 > - **Game mode miscellany:** Regular ('Marathon'), Swift ('40-Lines'), Classic & Master (unlocked after Regular), Puzzle, Cheese, Combo, Custom (select win condition, initial gravity, toggle gravity progress, *cmdline flags:* start board, seed).
 > - **Highscores, replays, statistics, ...** - can be viewed as well as backed up with a simple **savefile**.
 >

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ cargo run
 > - **Graphics:** Unicode/ASCII/Elektronika styles, old-terminal-compatible or very modern designs, 10 color palettes, hard drop/piece lock/line clear effects and much more.
 > - **Game keybinds:** to your heart's desire. 
 > - **Gameplay/handling:** Various rotation systems, piece randomizers, adjustable preview, timings (DAS¹, ARR¹, SDF¹, LCD, ARE), IRS/IHS/.. ([¹caveat](#why-do-some-gameplay-preferences-dasarrsdf-or-some-keybinds-ctrlshiftalt-not-work-for-me)).
+> - **Audio:** Optional asynchronous PC speaker (`pcspkr`) audio via `beep` for BGM and gameplay SFX, configurable in-app.
 > - **Game mode miscellany:** Regular ('Marathon'), Swift ('40-Lines'), Classic & Master (unlocked after Regular), Puzzle, Cheese, Combo, Custom (select win condition, initial gravity, toggle gravity progress, *cmdline flags:* start board, seed).
 > - **Highscores, replays, statistics, ...** - can be viewed as well as backed up with a simple **savefile**.
 >

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -83,6 +83,16 @@ impl AudioController {
         }
     }
 
+    pub fn play_welcome_melody(settings: AudioSettings) {
+        if !settings.enabled {
+            return;
+        }
+
+        let mut backend_state = AudioBackendState::Pending(settings.backend);
+        play_notes_blocking(&WELCOME_MELODY, 100, &mut backend_state);
+        reset_backend(backend_state);
+    }
+
     pub fn play_keypress(&self) {
         if self.settings.enabled && self.settings.sfx_enabled && self.settings.keypress_sfx {
             self.send(AudioCommand::PlaySfx(SoundEffect::Keypress));
@@ -447,9 +457,6 @@ fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child
             .arg(format!("{:.3}", f64::from(note.duration_ms) / 1000.0))
             .arg("sine")
             .arg(note.frequency_hz.to_string())
-            .arg("fade")
-            .arg("q")
-            .arg("0.005")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
@@ -576,6 +583,15 @@ const SFX_GAME_OVER_ARCADE: [Note; 6] = [
     n(440, 120, 6),
     n(392, 170, 6),
     n(330, 220, 10),
+];
+
+const WELCOME_MELODY: [Note; 6] = [
+    n(523, 70, 10),
+    n(659, 70, 10),
+    n(784, 90, 10),
+    n(988, 110, 10),
+    n(784, 80, 10),
+    n(1047, 150, 16),
 ];
 
 const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::VecDeque,
+    fs,
+    path::PathBuf,
     process::{Child, Command, Stdio},
+    sync::atomic::{AtomicU64, Ordering},
     sync::mpsc,
     thread,
     time::{Duration, Instant},
@@ -58,6 +61,12 @@ struct ActiveNotePlayback {
     deadline: Instant,
     kind: PlaybackKind,
     child: Option<Child>,
+    temp_path: Option<PathBuf>,
+}
+
+struct SpawnedNote {
+    child: Child,
+    temp_path: Option<PathBuf>,
 }
 
 pub struct AudioController {
@@ -129,13 +138,14 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
     let mut stop_requested = false;
     let mut backend_state = AudioBackendState::Pending(settings.backend);
     let mut active_note: Option<ActiveNotePlayback> = None;
+    let mut active_overlay_note: Option<ActiveNotePlayback> = None;
     let mut theme_resume_note: Option<PlaybackNote> = None;
     let tempo_percent = settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT);
     let theme = theme_notes(settings);
 
     loop {
         if stop_requested {
-            if stop_active_note(&mut active_note) {
+            if stop_active_note(&mut active_note) | stop_active_note(&mut active_overlay_note) {
                 reset_backend(backend_state);
             }
             break;
@@ -147,8 +157,15 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             finish_active_note(&mut active_note);
         }
 
+        if let Some(playback) = active_overlay_note.as_mut()
+            && Instant::now() >= playback.deadline
+        {
+            finish_active_note(&mut active_overlay_note);
+        }
+
         if let Some(playback) = active_note.as_mut()
             && !queued_sfx.is_empty()
+            && !backend_supports_overlay(settings.backend, backend_state)
             && matches!(
                 playback.kind,
                 PlaybackKind::Theme | PlaybackKind::ThemeResume
@@ -177,8 +194,22 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             stop_active_note(&mut active_note);
         }
 
+        if active_overlay_note.is_none()
+            && backend_supports_overlay(settings.backend, backend_state)
+            && start_next_sfx_note(
+                &mut queued_sfx,
+                tempo_percent,
+                &mut backend_state,
+                &mut active_overlay_note,
+            )
+        {
+            continue;
+        }
+
         if active_note.is_none() {
-            if let Some(notes) = queued_sfx.front_mut() {
+            if !backend_supports_overlay(settings.backend, backend_state)
+                && let Some(notes) = queued_sfx.front_mut()
+            {
                 if let Some((note, rest)) = next_note_in_slice(notes) {
                     if rest.is_empty() {
                         queued_sfx.pop_front();
@@ -219,7 +250,10 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
 
         let timeout = active_note
             .as_ref()
+            .into_iter()
+            .chain(active_overlay_note.as_ref())
             .map(|playback| playback.deadline.saturating_duration_since(Instant::now()))
+            .min()
             .unwrap_or(POLL_INTERVAL)
             .min(POLL_INTERVAL);
 
@@ -255,24 +289,24 @@ fn next_note_in_slice(notes: &'static [Note]) -> Option<(Note, &'static [Note])>
 }
 
 fn finish_active_note(active_note: &mut Option<ActiveNotePlayback>) {
-    if let Some(playback) = active_note.as_mut()
-        && let Some(child) = playback.child.as_mut()
-    {
-        let _ = child.try_wait();
+    if let Some(mut playback) = active_note.take() {
+        if let Some(child) = playback.child.as_mut() {
+            let _ = child.wait();
+        }
+        cleanup_temp_file(playback.temp_path.take());
     }
-    *active_note = None;
 }
 
 fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) -> bool {
     let mut was_playing = false;
-    if let Some(playback) = active_note.as_mut() {
+    if let Some(mut playback) = active_note.take() {
         was_playing = playback.child.is_some();
         if let Some(child) = playback.child.as_mut() {
             let _ = child.kill();
             let _ = child.wait();
         }
+        cleanup_temp_file(playback.temp_path.take());
     }
-    *active_note = None;
     was_playing
 }
 
@@ -298,10 +332,14 @@ fn play_note(
     backend_state: &mut AudioBackendState,
 ) -> ActiveNotePlayback {
     let start = Instant::now();
-    let child = if note.frequency_hz == 0 || note.duration_ms == 0 {
+    let spawned_note = if note.frequency_hz == 0 || note.duration_ms == 0 {
         None
     } else {
         spawn_note(note, backend_state)
+    };
+    let (child, temp_path) = match spawned_note {
+        Some(SpawnedNote { child, temp_path }) => (Some(child), temp_path),
+        None => (None, None),
     };
 
     ActiveNotePlayback {
@@ -310,14 +348,18 @@ fn play_note(
         deadline: start + Duration::from_millis(u64::from(note.duration_ms + note.rest_ms)),
         kind,
         child,
+        temp_path,
     }
 }
 
-fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Option<Child> {
+fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Option<SpawnedNote> {
     match *backend_state {
         AudioBackendState::Pending(AudioBackend::Auto) => {
             if let Some(child) = spawn_with_backend(AudioBackend::PcSpeakerBeep, note) {
                 *backend_state = AudioBackendState::Active(AudioBackend::PcSpeakerBeep);
+                Some(child)
+            } else if let Some(child) = spawn_with_backend(AudioBackend::SoundCardMidi, note) {
+                *backend_state = AudioBackendState::Active(AudioBackend::SoundCardMidi);
                 Some(child)
             } else if let Some(child) = spawn_with_backend(AudioBackend::SoundCardSox, note) {
                 *backend_state = AudioBackendState::Active(AudioBackend::SoundCardSox);
@@ -340,7 +382,7 @@ fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Opti
     }
 }
 
-fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child> {
+fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<SpawnedNote> {
     match backend {
         AudioBackend::Auto => None,
         AudioBackend::PcSpeakerBeep => Command::new("beep")
@@ -351,7 +393,12 @@ fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .ok(),
+            .ok()
+            .map(|child| SpawnedNote {
+                child,
+                temp_path: None,
+            }),
+        AudioBackend::SoundCardMidi => spawn_midi_note(note),
         AudioBackend::SoundCardSox => Command::new("sox")
             .arg("-q")
             .arg("-n")
@@ -360,11 +407,141 @@ fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child
             .arg(format!("{:.3}", f64::from(note.duration_ms) / 1000.0))
             .arg("sine")
             .arg(note.frequency_hz.to_string())
+            .arg("fade")
+            .arg("q")
+            .arg("0.005")
+            .arg(format!("{:.3}", f64::from(note.duration_ms) / 1000.0))
+            .arg("0.010")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .ok(),
+            .ok()
+            .map(|child| SpawnedNote {
+                child,
+                temp_path: None,
+            }),
     }
+}
+
+fn start_next_sfx_note(
+    queued_sfx: &mut VecDeque<&'static [Note]>,
+    tempo_percent: u16,
+    backend_state: &mut AudioBackendState,
+    active_note: &mut Option<ActiveNotePlayback>,
+) -> bool {
+    let Some(notes) = queued_sfx.front_mut() else {
+        return false;
+    };
+    let Some((note, rest)) = next_note_in_slice(notes) else {
+        queued_sfx.pop_front();
+        return false;
+    };
+
+    if rest.is_empty() {
+        queued_sfx.pop_front();
+    } else {
+        *notes = rest;
+    }
+
+    *active_note = Some(play_note(
+        scale_note(note, tempo_percent),
+        PlaybackKind::Sfx,
+        backend_state,
+    ));
+    true
+}
+
+fn backend_supports_overlay(
+    requested_backend: AudioBackend,
+    backend_state: AudioBackendState,
+) -> bool {
+    matches!(
+        backend_state,
+        AudioBackendState::Pending(AudioBackend::SoundCardMidi)
+            | AudioBackendState::Active(AudioBackend::SoundCardMidi)
+    ) || matches!(requested_backend, AudioBackend::SoundCardMidi)
+}
+
+fn spawn_midi_note(note: PlaybackNote) -> Option<SpawnedNote> {
+    let temp_path = create_temp_midi_file(note)?;
+    let child = Command::new("timidity")
+        .arg("-q")
+        .arg(&temp_path)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+    Some(SpawnedNote {
+        child,
+        temp_path: Some(temp_path),
+    })
+}
+
+fn create_temp_midi_file(note: PlaybackNote) -> Option<PathBuf> {
+    let temp_path = std::env::temp_dir().join(format!(
+        "tetro-tui-note-{}-{}.mid",
+        std::process::id(),
+        MIDI_FILE_ID.fetch_add(1, Ordering::Relaxed)
+    ));
+    fs::write(&temp_path, midi_bytes_for_note(note)).ok()?;
+    Some(temp_path)
+}
+
+fn cleanup_temp_file(temp_path: Option<PathBuf>) {
+    if let Some(temp_path) = temp_path {
+        let _ = fs::remove_file(temp_path);
+    }
+}
+
+fn midi_bytes_for_note(note: PlaybackNote) -> Vec<u8> {
+    let midi_note = frequency_hz_to_midi_note(note.frequency_hz);
+    let note_ticks = milliseconds_to_midi_ticks(note.duration_ms);
+    let release_ticks = milliseconds_to_midi_ticks(MIDI_RELEASE_MS);
+
+    let mut track = Vec::new();
+    track.extend([0x00, 0xFF, 0x51, 0x03, 0x07, 0xA1, 0x20]);
+    track.extend([0x00, 0xC0, MIDI_PROGRAM_LEAD_SQUARE]);
+    track.extend([0x00, 0x90, midi_note, MIDI_VELOCITY]);
+    push_midi_var_len(&mut track, note_ticks);
+    track.extend([0x80, midi_note, 0x40]);
+    push_midi_var_len(&mut track, release_ticks);
+    track.extend([0xFF, 0x2F, 0x00]);
+
+    let mut bytes = Vec::with_capacity(22 + track.len());
+    bytes.extend(b"MThd");
+    bytes.extend(6u32.to_be_bytes());
+    bytes.extend(0u16.to_be_bytes());
+    bytes.extend(1u16.to_be_bytes());
+    bytes.extend(MIDI_TICKS_PER_QUARTER.to_be_bytes());
+    bytes.extend(b"MTrk");
+    bytes.extend((track.len() as u32).to_be_bytes());
+    bytes.extend(track);
+    bytes
+}
+
+fn frequency_hz_to_midi_note(frequency_hz: u16) -> u8 {
+    let midi_note = 69.0 + 12.0 * (f64::from(frequency_hz) / 440.0).log2();
+    midi_note.round().clamp(0.0, 127.0) as u8
+}
+
+fn milliseconds_to_midi_ticks(duration_ms: u32) -> u32 {
+    ((u64::from(duration_ms).saturating_mul(u64::from(MIDI_TICKS_PER_QUARTER))) / 500)
+        .clamp(1, u64::from(u32::MAX)) as u32
+}
+
+fn push_midi_var_len(bytes: &mut Vec<u8>, value: u32) {
+    let mut buffer = [0u8; 5];
+    let mut index = buffer.len() - 1;
+    buffer[index] = (value & 0x7F) as u8;
+    let mut value = value >> 7;
+
+    while value > 0 {
+        index -= 1;
+        buffer[index] = ((value & 0x7F) as u8) | 0x80;
+        value >>= 7;
+    }
+
+    bytes.extend(&buffer[index..]);
 }
 
 fn scale_note(note: Note, tempo_percent: u16) -> PlaybackNote {
@@ -498,3 +675,8 @@ const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {
 
 const MIN_TEMPO_PERCENT: u16 = 20;
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
+const MIDI_PROGRAM_LEAD_SQUARE: u8 = 80;
+const MIDI_RELEASE_MS: u32 = 24;
+const MIDI_TICKS_PER_QUARTER: u16 = 480;
+const MIDI_VELOCITY: u8 = 96;
+static MIDI_FILE_ID: AtomicU64 = AtomicU64::new(0);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -176,15 +176,6 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
         }
 
         if active_note.is_none() {
-            if let Some(note) = theme_resume_note.take() {
-                active_note = Some(play_note(
-                    note,
-                    PlaybackKind::ThemeResume,
-                    &mut backend_state,
-                ));
-                continue;
-            }
-
             if let Some(notes) = queued_sfx.front_mut() {
                 if let Some((note, rest)) = next_note_in_slice(notes) {
                     if rest.is_empty() {
@@ -200,6 +191,15 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
                     continue;
                 }
                 queued_sfx.pop_front();
+                continue;
+            }
+
+            if let Some(note) = theme_resume_note.take() {
+                active_note = Some(play_note(
+                    note,
+                    PlaybackKind::ThemeResume,
+                    &mut backend_state,
+                ));
                 continue;
             }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -300,14 +300,13 @@ fn finish_active_note(active_note: &mut Option<ActiveNotePlayback>) {
 
 fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) -> bool {
     let mut was_playing = false;
-    if let Some(playback) = active_note.as_mut() {
+    if let Some(mut playback) = active_note.take() {
         was_playing = playback.child.is_some();
         if let Some(child) = playback.child.as_mut() {
             let _ = child.kill();
             let _ = child.wait();
         }
     }
-    *active_note = None;
     was_playing
 }
 
@@ -365,7 +364,9 @@ fn play_notes_blocking(
 }
 
 fn wait_for_note_completion(mut playback: ActiveNotePlayback) {
-    if let Some(child) = playback.child.as_mut() {
+    if let Some(child) = playback.child.as_mut()
+        && !matches!(child.try_wait(), Ok(Some(_)))
+    {
         let _ = child.wait();
     }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,315 @@
+use std::{
+    collections::VecDeque,
+    io::Write,
+    process::Command,
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use crate::{
+    core_game_engine::{Notification, NotificationFeed},
+    settings::{AudioSettings, SfxPack, ThemeSong},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub enum SoundEffect {
+    Keypress,
+    PieceLock,
+    LineClear { lines: u32 },
+    GameOver,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Note {
+    frequency_hz: u16,
+    duration_ms: u16,
+    rest_ms: u16,
+}
+
+enum AudioCommand {
+    PlaySfx(SoundEffect),
+    Stop,
+}
+
+pub struct AudioController {
+    settings: AudioSettings,
+    sender: Option<mpsc::Sender<AudioCommand>>,
+}
+
+impl AudioController {
+    pub fn new(settings: AudioSettings) -> Self {
+        if !settings.enabled {
+            return Self {
+                settings,
+                sender: None,
+            };
+        }
+
+        let (sender, receiver) = mpsc::channel::<AudioCommand>();
+        thread::spawn(move || audio_worker(receiver, settings));
+        Self {
+            settings,
+            sender: Some(sender),
+        }
+    }
+
+    pub fn play_keypress(&self) {
+        if self.settings.enabled && self.settings.sfx_enabled && self.settings.keypress_sfx {
+            self.send(AudioCommand::PlaySfx(SoundEffect::Keypress));
+        }
+    }
+
+    pub fn play_from_notifications(&self, feed: &NotificationFeed) {
+        if !(self.settings.enabled && self.settings.sfx_enabled) {
+            return;
+        }
+        for (notification, _) in feed {
+            match notification {
+                Notification::PieceLocked { .. } if self.settings.piece_lock_sfx => {
+                    self.send(AudioCommand::PlaySfx(SoundEffect::PieceLock));
+                }
+                Notification::Accolade { lineclears, .. } if self.settings.line_clear_sfx => {
+                    self.send(AudioCommand::PlaySfx(SoundEffect::LineClear { lines: *lineclears }));
+                }
+                Notification::GameEnded { is_win: false, .. } if self.settings.game_over_sfx => {
+                    self.send(AudioCommand::PlaySfx(SoundEffect::GameOver));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn send(&self, command: AudioCommand) {
+        if let Some(sender) = &self.sender {
+            let _ = sender.send(command);
+        }
+    }
+}
+
+impl Drop for AudioController {
+    fn drop(&mut self) {
+        self.send(AudioCommand::Stop);
+    }
+}
+
+fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings) {
+    let mut queued_sfx: VecDeque<&'static [Note]> = VecDeque::new();
+    let mut theme_index = 0usize;
+    let mut stop = false;
+
+    while !stop {
+        match receiver.recv_timeout(Duration::from_millis(5)) {
+            Ok(AudioCommand::PlaySfx(effect)) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+            Ok(AudioCommand::Stop) => stop = true,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+
+        while let Ok(command) = receiver.try_recv() {
+            match command {
+                AudioCommand::PlaySfx(effect) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+                AudioCommand::Stop => {
+                    stop = true;
+                    break;
+                }
+            }
+        }
+
+        if stop {
+            break;
+        }
+
+        if let Some(notes) = queued_sfx.pop_front() {
+            play_notes(notes, settings.theme_tempo_percent.max(20));
+            continue;
+        }
+
+        if settings.theme_enabled {
+            let theme = theme_notes(settings.theme_song);
+            let note = theme[theme_index % theme.len()];
+            theme_index += 1;
+            play_note(note, settings.theme_tempo_percent.max(20));
+        } else {
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+}
+
+fn play_notes(notes: &[Note], tempo_percent: u16) {
+    for note in notes {
+        play_note(*note, tempo_percent);
+    }
+}
+
+fn play_note(note: Note, tempo_percent: u16) {
+    let scaled_duration_ms = (u32::from(note.duration_ms) * 100)
+        .checked_div(u32::from(tempo_percent))
+        .unwrap_or(u32::from(note.duration_ms))
+        .clamp(1, 10_000);
+    let scaled_rest_ms = (u32::from(note.rest_ms) * 100)
+        .checked_div(u32::from(tempo_percent))
+        .unwrap_or(u32::from(note.rest_ms))
+        .clamp(0, 10_000);
+
+    if note.frequency_hz == 0 {
+        thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
+    } else {
+        let status = Command::new("beep")
+            .arg("-f")
+            .arg(note.frequency_hz.to_string())
+            .arg("-l")
+            .arg(scaled_duration_ms.to_string())
+            .status();
+
+        if status.is_err() {
+            let _ = std::io::stdout().write_all(b"\x07");
+            let _ = std::io::stdout().flush();
+            thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
+        }
+    }
+
+    if scaled_rest_ms > 0 {
+        thread::sleep(Duration::from_millis(u64::from(scaled_rest_ms)));
+    }
+}
+
+fn notes_for_sfx(effect: SoundEffect, settings: AudioSettings) -> &'static [Note] {
+    match (settings.sfx_pack, effect) {
+        (SfxPack::Classic, SoundEffect::Keypress) => &SFX_KEYPRESS_CLASSIC,
+        (SfxPack::Classic, SoundEffect::PieceLock) => &SFX_PIECE_LOCK_CLASSIC,
+        (SfxPack::Classic, SoundEffect::LineClear { lines }) if lines >= 4 => {
+            &SFX_LINE_CLEAR_TETRIS_CLASSIC
+        }
+        (SfxPack::Classic, SoundEffect::LineClear { .. }) => &SFX_LINE_CLEAR_CLASSIC,
+        (SfxPack::Classic, SoundEffect::GameOver) => &SFX_GAME_OVER_CLASSIC,
+        (SfxPack::Arcade, SoundEffect::Keypress) => &SFX_KEYPRESS_ARCADE,
+        (SfxPack::Arcade, SoundEffect::PieceLock) => &SFX_PIECE_LOCK_ARCADE,
+        (SfxPack::Arcade, SoundEffect::LineClear { lines }) if lines >= 4 => {
+            &SFX_LINE_CLEAR_TETRIS_ARCADE
+        }
+        (SfxPack::Arcade, SoundEffect::LineClear { .. }) => &SFX_LINE_CLEAR_ARCADE,
+        (SfxPack::Arcade, SoundEffect::GameOver) => &SFX_GAME_OVER_ARCADE,
+    }
+}
+
+fn theme_notes(song: ThemeSong) -> &'static [Note] {
+    match song {
+        ThemeSong::KorobeinikiA => &THEME_KOROBEINIKI_A,
+        ThemeSong::KorobeinikiB => &THEME_KOROBEINIKI_B,
+    }
+}
+
+const THEME_KOROBEINIKI_A: [Note; 32] = [
+    n(659, 125, 10),
+    n(494, 63, 10),
+    n(523, 63, 10),
+    n(587, 125, 10),
+    n(523, 63, 10),
+    n(494, 63, 10),
+    n(440, 125, 10),
+    n(440, 63, 10),
+    n(523, 63, 10),
+    n(659, 125, 10),
+    n(587, 63, 10),
+    n(523, 63, 10),
+    n(494, 188, 20),
+    n(523, 63, 10),
+    n(587, 125, 10),
+    n(659, 125, 10),
+    n(523, 125, 10),
+    n(440, 125, 10),
+    n(440, 125, 10),
+    n(0, 63, 15),
+    n(587, 125, 10),
+    n(698, 63, 10),
+    n(880, 125, 10),
+    n(784, 63, 10),
+    n(698, 63, 10),
+    n(659, 188, 15),
+    n(523, 63, 10),
+    n(659, 125, 10),
+    n(587, 63, 10),
+    n(523, 63, 10),
+    n(494, 188, 20),
+    n(0, 63, 15),
+];
+
+const THEME_KOROBEINIKI_B: [Note; 24] = [
+    n(659, 150, 8),
+    n(523, 75, 8),
+    n(587, 75, 8),
+    n(659, 150, 8),
+    n(587, 75, 8),
+    n(523, 75, 8),
+    n(494, 150, 8),
+    n(494, 75, 8),
+    n(587, 75, 8),
+    n(698, 150, 8),
+    n(659, 75, 8),
+    n(587, 75, 8),
+    n(523, 150, 8),
+    n(523, 75, 8),
+    n(587, 75, 8),
+    n(659, 150, 8),
+    n(698, 75, 8),
+    n(784, 75, 8),
+    n(880, 225, 18),
+    n(784, 75, 8),
+    n(698, 75, 8),
+    n(659, 150, 8),
+    n(587, 150, 8),
+    n(0, 75, 20),
+];
+
+const SFX_KEYPRESS_CLASSIC: [Note; 1] = [n(880, 22, 3)];
+const SFX_PIECE_LOCK_CLASSIC: [Note; 2] = [n(392, 30, 2), n(330, 38, 4)];
+const SFX_LINE_CLEAR_CLASSIC: [Note; 3] = [n(523, 45, 2), n(659, 45, 2), n(784, 65, 8)];
+const SFX_LINE_CLEAR_TETRIS_CLASSIC: [Note; 5] = [
+    n(523, 40, 2),
+    n(659, 40, 2),
+    n(784, 40, 2),
+    n(988, 55, 2),
+    n(1319, 95, 8),
+];
+const SFX_GAME_OVER_CLASSIC: [Note; 6] = [
+    n(392, 110, 8),
+    n(370, 110, 8),
+    n(349, 110, 8),
+    n(330, 150, 8),
+    n(262, 220, 12),
+    n(196, 280, 12),
+];
+
+const SFX_KEYPRESS_ARCADE: [Note; 2] = [n(988, 18, 2), n(1175, 20, 3)];
+const SFX_PIECE_LOCK_ARCADE: [Note; 3] = [n(440, 22, 2), n(349, 24, 2), n(262, 45, 4)];
+const SFX_LINE_CLEAR_ARCADE: [Note; 4] = [
+    n(659, 35, 2),
+    n(784, 35, 2),
+    n(988, 35, 2),
+    n(1175, 70, 8),
+];
+const SFX_LINE_CLEAR_TETRIS_ARCADE: [Note; 6] = [
+    n(523, 32, 2),
+    n(659, 32, 2),
+    n(784, 32, 2),
+    n(1047, 32, 2),
+    n(1319, 70, 2),
+    n(1568, 95, 8),
+];
+const SFX_GAME_OVER_ARCADE: [Note; 6] = [
+    n(523, 90, 6),
+    n(494, 90, 6),
+    n(466, 90, 6),
+    n(440, 120, 6),
+    n(392, 170, 6),
+    n(330, 220, 10),
+];
+
+const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {
+    Note {
+        frequency_hz,
+        duration_ms,
+        rest_ms,
+    }
+}

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -135,7 +135,9 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
 
     loop {
         if stop_requested {
-            stop_active_note(&mut active_note);
+            if stop_active_note(&mut active_note) {
+                reset_backend(backend_state);
+            }
             break;
         }
 
@@ -226,7 +228,7 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
                 queued_sfx.push_back(notes_for_sfx(effect, settings))
             }
             Ok(AudioCommand::Stop) => stop_requested = true,
-            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Disconnected) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
 
@@ -261,14 +263,33 @@ fn finish_active_note(active_note: &mut Option<ActiveNotePlayback>) {
     *active_note = None;
 }
 
-fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) {
-    if let Some(playback) = active_note.as_mut()
-        && let Some(child) = playback.child.as_mut()
-    {
-        let _ = child.kill();
-        let _ = child.wait();
+fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) -> bool {
+    let mut was_playing = false;
+    if let Some(playback) = active_note.as_mut() {
+        was_playing = playback.child.is_some();
+        if let Some(child) = playback.child.as_mut() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
     }
     *active_note = None;
+    was_playing
+}
+
+fn reset_backend(backend_state: AudioBackendState) {
+    if matches!(
+        backend_state,
+        AudioBackendState::Active(AudioBackend::PcSpeakerBeep)
+    ) {
+        let _ = Command::new("beep")
+            .arg("-f")
+            .arg("440")
+            .arg("-l")
+            .arg("0")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
 }
 
 fn play_note(

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::VecDeque,
-    fs,
-    path::PathBuf,
     process::{Child, Command, Stdio},
-    sync::atomic::{AtomicU64, Ordering},
     sync::mpsc,
     thread,
     time::{Duration, Instant},
@@ -38,6 +35,7 @@ struct PlaybackNote {
 
 enum AudioCommand {
     PlaySfx(SoundEffect),
+    StopAndPlaySfx(SoundEffect, mpsc::Sender<()>),
     Stop,
 }
 
@@ -61,12 +59,6 @@ struct ActiveNotePlayback {
     deadline: Instant,
     kind: PlaybackKind,
     child: Option<Child>,
-    temp_path: Option<PathBuf>,
-}
-
-struct SpawnedNote {
-    child: Child,
-    temp_path: Option<PathBuf>,
 }
 
 pub struct AudioController {
@@ -111,11 +103,29 @@ impl AudioController {
                         lines: *lineclears,
                     }));
                 }
-                Notification::GameEnded { is_win: false, .. } if self.settings.game_over_sfx => {
-                    self.send(AudioCommand::PlaySfx(SoundEffect::GameOver));
-                }
                 _ => {}
             }
+        }
+    }
+
+    pub fn stop_and_play_game_over(&self) {
+        if !(self.settings.enabled && self.settings.sfx_enabled && self.settings.game_over_sfx) {
+            return;
+        }
+
+        let Some(sender) = &self.sender else {
+            return;
+        };
+
+        let (done_sender, done_receiver) = mpsc::channel();
+        if sender
+            .send(AudioCommand::StopAndPlaySfx(
+                SoundEffect::GameOver,
+                done_sender,
+            ))
+            .is_ok()
+        {
+            let _ = done_receiver.recv();
         }
     }
 
@@ -138,14 +148,13 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
     let mut stop_requested = false;
     let mut backend_state = AudioBackendState::Pending(settings.backend);
     let mut active_note: Option<ActiveNotePlayback> = None;
-    let mut active_overlay_note: Option<ActiveNotePlayback> = None;
     let mut theme_resume_note: Option<PlaybackNote> = None;
     let tempo_percent = settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT);
     let theme = theme_notes(settings);
 
     loop {
         if stop_requested {
-            if stop_active_note(&mut active_note) | stop_active_note(&mut active_overlay_note) {
+            if stop_active_note(&mut active_note) {
                 reset_backend(backend_state);
             }
             break;
@@ -157,15 +166,8 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             finish_active_note(&mut active_note);
         }
 
-        if let Some(playback) = active_overlay_note.as_mut()
-            && Instant::now() >= playback.deadline
-        {
-            finish_active_note(&mut active_overlay_note);
-        }
-
         if let Some(playback) = active_note.as_mut()
             && !queued_sfx.is_empty()
-            && !backend_supports_overlay(settings.backend, backend_state)
             && matches!(
                 playback.kind,
                 PlaybackKind::Theme | PlaybackKind::ThemeResume
@@ -194,22 +196,8 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             stop_active_note(&mut active_note);
         }
 
-        if active_overlay_note.is_none()
-            && backend_supports_overlay(settings.backend, backend_state)
-            && start_next_sfx_note(
-                &mut queued_sfx,
-                tempo_percent,
-                &mut backend_state,
-                &mut active_overlay_note,
-            )
-        {
-            continue;
-        }
-
         if active_note.is_none() {
-            if !backend_supports_overlay(settings.backend, backend_state)
-                && let Some(notes) = queued_sfx.front_mut()
-            {
+            if let Some(notes) = queued_sfx.front_mut() {
                 if let Some((note, rest)) = next_note_in_slice(notes) {
                     if rest.is_empty() {
                         queued_sfx.pop_front();
@@ -250,10 +238,7 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
 
         let timeout = active_note
             .as_ref()
-            .into_iter()
-            .chain(active_overlay_note.as_ref())
             .map(|playback| playback.deadline.saturating_duration_since(Instant::now()))
-            .min()
             .unwrap_or(POLL_INTERVAL)
             .min(POLL_INTERVAL);
 
@@ -261,25 +246,44 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             Ok(AudioCommand::PlaySfx(effect)) => {
                 queued_sfx.push_back(notes_for_sfx(effect, settings))
             }
+            Ok(AudioCommand::StopAndPlaySfx(effect, done_sender)) => {
+                stop_and_play_sfx(
+                    effect,
+                    settings,
+                    tempo_percent,
+                    &mut queued_sfx,
+                    &mut active_note,
+                    &mut theme_resume_note,
+                    &mut backend_state,
+                );
+                let _ = done_sender.send(());
+                stop_requested = true;
+            }
             Ok(AudioCommand::Stop) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Disconnected) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
 
-        drain_commands(&receiver, &mut queued_sfx, settings, &mut stop_requested);
-    }
-}
-
-fn drain_commands(
-    receiver: &mpsc::Receiver<AudioCommand>,
-    queued_sfx: &mut VecDeque<&'static [Note]>,
-    settings: AudioSettings,
-    stop_requested: &mut bool,
-) {
-    while let Ok(command) = receiver.try_recv() {
-        match command {
-            AudioCommand::PlaySfx(effect) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
-            AudioCommand::Stop => *stop_requested = true,
+        while let Ok(command) = receiver.try_recv() {
+            match command {
+                AudioCommand::PlaySfx(effect) => {
+                    queued_sfx.push_back(notes_for_sfx(effect, settings))
+                }
+                AudioCommand::StopAndPlaySfx(effect, done_sender) => {
+                    stop_and_play_sfx(
+                        effect,
+                        settings,
+                        tempo_percent,
+                        &mut queued_sfx,
+                        &mut active_note,
+                        &mut theme_resume_note,
+                        &mut backend_state,
+                    );
+                    let _ = done_sender.send(());
+                    stop_requested = true;
+                }
+                AudioCommand::Stop => stop_requested = true,
+            }
         }
     }
 }
@@ -289,24 +293,21 @@ fn next_note_in_slice(notes: &'static [Note]) -> Option<(Note, &'static [Note])>
 }
 
 fn finish_active_note(active_note: &mut Option<ActiveNotePlayback>) {
-    if let Some(mut playback) = active_note.take() {
-        if let Some(child) = playback.child.as_mut() {
-            let _ = child.wait();
-        }
-        cleanup_temp_file(playback.temp_path.take());
+    if let Some(playback) = active_note.take() {
+        wait_for_note_completion(playback);
     }
 }
 
 fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) -> bool {
     let mut was_playing = false;
-    if let Some(mut playback) = active_note.take() {
+    if let Some(playback) = active_note.as_mut() {
         was_playing = playback.child.is_some();
         if let Some(child) = playback.child.as_mut() {
             let _ = child.kill();
             let _ = child.wait();
         }
-        cleanup_temp_file(playback.temp_path.take());
     }
+    *active_note = None;
     was_playing
 }
 
@@ -326,20 +327,67 @@ fn reset_backend(backend_state: AudioBackendState) {
     }
 }
 
+fn stop_and_play_sfx(
+    effect: SoundEffect,
+    settings: AudioSettings,
+    tempo_percent: u16,
+    queued_sfx: &mut VecDeque<&'static [Note]>,
+    active_note: &mut Option<ActiveNotePlayback>,
+    theme_resume_note: &mut Option<PlaybackNote>,
+    backend_state: &mut AudioBackendState,
+) {
+    queued_sfx.clear();
+    *theme_resume_note = None;
+
+    if stop_active_note(active_note) {
+        reset_backend(*backend_state);
+    }
+
+    play_notes_blocking(
+        notes_for_sfx(effect, settings),
+        tempo_percent,
+        backend_state,
+    );
+}
+
+fn play_notes_blocking(
+    notes: &'static [Note],
+    tempo_percent: u16,
+    backend_state: &mut AudioBackendState,
+) {
+    for note in notes {
+        wait_for_note_completion(play_note(
+            scale_note(*note, tempo_percent),
+            PlaybackKind::Sfx,
+            backend_state,
+        ));
+    }
+}
+
+fn wait_for_note_completion(mut playback: ActiveNotePlayback) {
+    if let Some(child) = playback.child.as_mut() {
+        let _ = child.wait();
+    }
+
+    if let Some(remaining) = playback
+        .deadline
+        .checked_duration_since(Instant::now())
+        .filter(|remaining| !remaining.is_zero())
+    {
+        thread::sleep(remaining);
+    }
+}
+
 fn play_note(
     note: PlaybackNote,
     kind: PlaybackKind,
     backend_state: &mut AudioBackendState,
 ) -> ActiveNotePlayback {
     let start = Instant::now();
-    let spawned_note = if note.frequency_hz == 0 || note.duration_ms == 0 {
+    let child = if note.frequency_hz == 0 || note.duration_ms == 0 {
         None
     } else {
         spawn_note(note, backend_state)
-    };
-    let (child, temp_path) = match spawned_note {
-        Some(SpawnedNote { child, temp_path }) => (Some(child), temp_path),
-        None => (None, None),
     };
 
     ActiveNotePlayback {
@@ -348,18 +396,14 @@ fn play_note(
         deadline: start + Duration::from_millis(u64::from(note.duration_ms + note.rest_ms)),
         kind,
         child,
-        temp_path,
     }
 }
 
-fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Option<SpawnedNote> {
+fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Option<Child> {
     match *backend_state {
         AudioBackendState::Pending(AudioBackend::Auto) => {
             if let Some(child) = spawn_with_backend(AudioBackend::PcSpeakerBeep, note) {
                 *backend_state = AudioBackendState::Active(AudioBackend::PcSpeakerBeep);
-                Some(child)
-            } else if let Some(child) = spawn_with_backend(AudioBackend::SoundCardMidi, note) {
-                *backend_state = AudioBackendState::Active(AudioBackend::SoundCardMidi);
                 Some(child)
             } else if let Some(child) = spawn_with_backend(AudioBackend::SoundCardSox, note) {
                 *backend_state = AudioBackendState::Active(AudioBackend::SoundCardSox);
@@ -382,7 +426,7 @@ fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Opti
     }
 }
 
-fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<SpawnedNote> {
+fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child> {
     match backend {
         AudioBackend::Auto => None,
         AudioBackend::PcSpeakerBeep => Command::new("beep")
@@ -393,12 +437,7 @@ fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Spawn
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .ok()
-            .map(|child| SpawnedNote {
-                child,
-                temp_path: None,
-            }),
-        AudioBackend::SoundCardMidi => spawn_midi_note(note),
+            .ok(),
         AudioBackend::SoundCardSox => Command::new("sox")
             .arg("-q")
             .arg("-n")
@@ -410,138 +449,11 @@ fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Spawn
             .arg("fade")
             .arg("q")
             .arg("0.005")
-            .arg(format!("{:.3}", f64::from(note.duration_ms) / 1000.0))
-            .arg("0.010")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
-            .ok()
-            .map(|child| SpawnedNote {
-                child,
-                temp_path: None,
-            }),
+            .ok(),
     }
-}
-
-fn start_next_sfx_note(
-    queued_sfx: &mut VecDeque<&'static [Note]>,
-    tempo_percent: u16,
-    backend_state: &mut AudioBackendState,
-    active_note: &mut Option<ActiveNotePlayback>,
-) -> bool {
-    let Some(notes) = queued_sfx.front_mut() else {
-        return false;
-    };
-    let Some((note, rest)) = next_note_in_slice(notes) else {
-        queued_sfx.pop_front();
-        return false;
-    };
-
-    if rest.is_empty() {
-        queued_sfx.pop_front();
-    } else {
-        *notes = rest;
-    }
-
-    *active_note = Some(play_note(
-        scale_note(note, tempo_percent),
-        PlaybackKind::Sfx,
-        backend_state,
-    ));
-    true
-}
-
-fn backend_supports_overlay(
-    requested_backend: AudioBackend,
-    backend_state: AudioBackendState,
-) -> bool {
-    matches!(
-        backend_state,
-        AudioBackendState::Pending(AudioBackend::SoundCardMidi)
-            | AudioBackendState::Active(AudioBackend::SoundCardMidi)
-    ) || matches!(requested_backend, AudioBackend::SoundCardMidi)
-}
-
-fn spawn_midi_note(note: PlaybackNote) -> Option<SpawnedNote> {
-    let temp_path = create_temp_midi_file(note)?;
-    let child = Command::new("timidity")
-        .arg("-q")
-        .arg(&temp_path)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-    Some(SpawnedNote {
-        child,
-        temp_path: Some(temp_path),
-    })
-}
-
-fn create_temp_midi_file(note: PlaybackNote) -> Option<PathBuf> {
-    let temp_path = std::env::temp_dir().join(format!(
-        "tetro-tui-note-{}-{}.mid",
-        std::process::id(),
-        MIDI_FILE_ID.fetch_add(1, Ordering::Relaxed)
-    ));
-    fs::write(&temp_path, midi_bytes_for_note(note)).ok()?;
-    Some(temp_path)
-}
-
-fn cleanup_temp_file(temp_path: Option<PathBuf>) {
-    if let Some(temp_path) = temp_path {
-        let _ = fs::remove_file(temp_path);
-    }
-}
-
-fn midi_bytes_for_note(note: PlaybackNote) -> Vec<u8> {
-    let midi_note = frequency_hz_to_midi_note(note.frequency_hz);
-    let note_ticks = milliseconds_to_midi_ticks(note.duration_ms);
-    let release_ticks = milliseconds_to_midi_ticks(MIDI_RELEASE_MS);
-
-    let mut track = Vec::new();
-    track.extend([0x00, 0xFF, 0x51, 0x03, 0x07, 0xA1, 0x20]);
-    track.extend([0x00, 0xC0, MIDI_PROGRAM_LEAD_SQUARE]);
-    track.extend([0x00, 0x90, midi_note, MIDI_VELOCITY]);
-    push_midi_var_len(&mut track, note_ticks);
-    track.extend([0x80, midi_note, 0x40]);
-    push_midi_var_len(&mut track, release_ticks);
-    track.extend([0xFF, 0x2F, 0x00]);
-
-    let mut bytes = Vec::with_capacity(22 + track.len());
-    bytes.extend(b"MThd");
-    bytes.extend(6u32.to_be_bytes());
-    bytes.extend(0u16.to_be_bytes());
-    bytes.extend(1u16.to_be_bytes());
-    bytes.extend(MIDI_TICKS_PER_QUARTER.to_be_bytes());
-    bytes.extend(b"MTrk");
-    bytes.extend((track.len() as u32).to_be_bytes());
-    bytes.extend(track);
-    bytes
-}
-
-fn frequency_hz_to_midi_note(frequency_hz: u16) -> u8 {
-    let midi_note = 69.0 + 12.0 * (f64::from(frequency_hz) / 440.0).log2();
-    midi_note.round().clamp(0.0, 127.0) as u8
-}
-
-fn milliseconds_to_midi_ticks(duration_ms: u32) -> u32 {
-    ((u64::from(duration_ms).saturating_mul(u64::from(MIDI_TICKS_PER_QUARTER))) / 500)
-        .clamp(1, u64::from(u32::MAX)) as u32
-}
-
-fn push_midi_var_len(bytes: &mut Vec<u8>, value: u32) {
-    let mut buffer = [0u8; 5];
-    let mut index = buffer.len() - 1;
-    buffer[index] = (value & 0x7F) as u8;
-    let mut value = value >> 7;
-
-    while value > 0 {
-        index -= 1;
-        buffer[index] = ((value & 0x7F) as u8) | 0x80;
-        value >>= 7;
-    }
-
-    bytes.extend(&buffer[index..]);
 }
 
 fn scale_note(note: Note, tempo_percent: u16) -> PlaybackNote {
@@ -675,8 +587,3 @@ const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {
 
 const MIN_TEMPO_PERCENT: u16 = 20;
 const POLL_INTERVAL: Duration = Duration::from_millis(5);
-const MIDI_PROGRAM_LEAD_SQUARE: u8 = 80;
-const MIDI_RELEASE_MS: u32 = 24;
-const MIDI_TICKS_PER_QUARTER: u16 = 480;
-const MIDI_VELOCITY: u8 = 96;
-static MIDI_FILE_ID: AtomicU64 = AtomicU64::new(0);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,8 +1,14 @@
-use std::{collections::VecDeque, io::Write, process::Command, sync::mpsc, thread, time::Duration};
+use std::{
+    collections::VecDeque,
+    process::{Child, Command, Stdio},
+    sync::mpsc,
+    thread,
+    time::{Duration, Instant},
+};
 
 use crate::{
     core_game_engine::{Notification, NotificationFeed},
-    settings::{AudioSettings, SfxPack, ThemeSong},
+    settings::{AudioBackend, AudioSettings, SfxPack},
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -20,16 +26,38 @@ struct Note {
     rest_ms: u16,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct PlaybackNote {
+    frequency_hz: u16,
+    duration_ms: u32,
+    rest_ms: u32,
+}
+
 enum AudioCommand {
     PlaySfx(SoundEffect),
     Stop,
 }
 
 #[derive(Clone, Copy, Debug)]
-enum PcSpkrAvailability {
-    Unknown,
-    Available,
+enum AudioBackendState {
+    Pending(AudioBackend),
+    Active(AudioBackend),
     Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PlaybackKind {
+    Theme,
+    ThemeResume,
+    Sfx,
+}
+
+struct ActiveNotePlayback {
+    note: PlaybackNote,
+    sound_deadline: Instant,
+    deadline: Instant,
+    kind: PlaybackKind,
+    child: Option<Child>,
 }
 
 pub struct AudioController {
@@ -99,108 +127,231 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
     let mut queued_sfx: VecDeque<&'static [Note]> = VecDeque::new();
     let mut theme_index = 0usize;
     let mut stop_requested = false;
-    let mut pcspkr_availability = PcSpkrAvailability::Unknown;
+    let mut backend_state = AudioBackendState::Pending(settings.backend);
+    let mut active_note: Option<ActiveNotePlayback> = None;
+    let mut theme_resume_note: Option<PlaybackNote> = None;
+    let tempo_percent = settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT);
+    let theme = theme_notes(settings);
 
     loop {
-        match receiver.recv_timeout(Duration::from_millis(5)) {
-            Ok(AudioCommand::PlaySfx(effect)) => {
-                queued_sfx.push_back(notes_for_sfx(effect, settings))
+        if stop_requested {
+            stop_active_note(&mut active_note);
+            break;
+        }
+
+        if let Some(playback) = active_note.as_mut() {
+            if Instant::now() >= playback.deadline {
+                finish_active_note(&mut active_note);
             }
+        }
+
+        if let Some(playback) = active_note.as_mut()
+            && !queued_sfx.is_empty()
+            && matches!(playback.kind, PlaybackKind::Theme | PlaybackKind::ThemeResume)
+        {
+            let now = Instant::now();
+            let remaining_duration_ms = playback
+                .sound_deadline
+                .saturating_duration_since(now)
+                .as_millis()
+                .try_into()
+                .unwrap_or(u32::MAX);
+            let remaining_rest_ms = playback
+                .deadline
+                .saturating_duration_since(playback.sound_deadline.max(now))
+                .as_millis()
+                .try_into()
+                .unwrap_or(u32::MAX);
+
+            theme_resume_note = (remaining_duration_ms > 0 || remaining_rest_ms > 0).then_some(
+                PlaybackNote {
+                    frequency_hz: playback.note.frequency_hz,
+                    duration_ms: remaining_duration_ms,
+                    rest_ms: remaining_rest_ms,
+                },
+            );
+            stop_active_note(&mut active_note);
+        }
+
+        if active_note.is_none() {
+            if let Some(note) = theme_resume_note.take() {
+                active_note = Some(play_note(note, PlaybackKind::ThemeResume, &mut backend_state));
+                continue;
+            }
+
+            if let Some(notes) = queued_sfx.front_mut() {
+                if let Some((note, rest)) = next_note_in_slice(notes) {
+                    if rest.is_empty() {
+                        queued_sfx.pop_front();
+                    } else {
+                        *notes = rest;
+                    }
+                    active_note = Some(play_note(
+                        scale_note(note, tempo_percent),
+                        PlaybackKind::Sfx,
+                        &mut backend_state,
+                    ));
+                    continue;
+                }
+                queued_sfx.pop_front();
+                continue;
+            }
+
+            if settings.theme_enabled {
+                let note = theme[theme_index % theme.len()];
+                theme_index = (theme_index + 1) % theme.len();
+                active_note = Some(play_note(
+                    scale_note(note, tempo_percent),
+                    PlaybackKind::Theme,
+                    &mut backend_state,
+                ));
+                continue;
+            }
+        }
+
+        let timeout = active_note
+            .as_ref()
+            .map(|playback| playback.deadline.saturating_duration_since(Instant::now()))
+            .unwrap_or(POLL_INTERVAL)
+            .min(POLL_INTERVAL);
+
+        match receiver.recv_timeout(timeout) {
+            Ok(AudioCommand::PlaySfx(effect)) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
             Ok(AudioCommand::Stop) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
 
-        while let Ok(command) = receiver.try_recv() {
-            match command {
-                AudioCommand::PlaySfx(effect) => {
-                    queued_sfx.push_back(notes_for_sfx(effect, settings))
-                }
-                AudioCommand::Stop => {
-                    stop_requested = true;
-                }
+        drain_commands(&receiver, &mut queued_sfx, settings, &mut stop_requested);
+    }
+}
+
+fn drain_commands(
+    receiver: &mpsc::Receiver<AudioCommand>,
+    queued_sfx: &mut VecDeque<&'static [Note]>,
+    settings: AudioSettings,
+    stop_requested: &mut bool,
+) {
+    while let Ok(command) = receiver.try_recv() {
+        match command {
+            AudioCommand::PlaySfx(effect) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+            AudioCommand::Stop => *stop_requested = true,
+        }
+    }
+}
+
+fn next_note_in_slice(notes: &'static [Note]) -> Option<(Note, &'static [Note])> {
+    notes.split_first().map(|(first, rest)| (*first, rest))
+}
+
+fn finish_active_note(active_note: &mut Option<ActiveNotePlayback>) {
+    if let Some(playback) = active_note.as_mut()
+        && let Some(child) = playback.child.as_mut()
+    {
+        let _ = child.try_wait();
+    }
+    *active_note = None;
+}
+
+fn stop_active_note(active_note: &mut Option<ActiveNotePlayback>) {
+    if let Some(playback) = active_note.as_mut()
+        && let Some(child) = playback.child.as_mut()
+    {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    *active_note = None;
+}
+
+fn play_note(
+    note: PlaybackNote,
+    kind: PlaybackKind,
+    backend_state: &mut AudioBackendState,
+) -> ActiveNotePlayback {
+    let start = Instant::now();
+    let child = if note.frequency_hz == 0 || note.duration_ms == 0 {
+        None
+    } else {
+        spawn_note(note, backend_state)
+    };
+
+    ActiveNotePlayback {
+        note,
+        sound_deadline: start + Duration::from_millis(u64::from(note.duration_ms)),
+        deadline: start + Duration::from_millis(u64::from(note.duration_ms + note.rest_ms)),
+        kind,
+        child,
+    }
+}
+
+fn spawn_note(note: PlaybackNote, backend_state: &mut AudioBackendState) -> Option<Child> {
+    match *backend_state {
+        AudioBackendState::Pending(AudioBackend::Auto) => {
+            if let Some(child) = spawn_with_backend(AudioBackend::PcSpeakerBeep, note) {
+                *backend_state = AudioBackendState::Active(AudioBackend::PcSpeakerBeep);
+                Some(child)
+            } else if let Some(child) = spawn_with_backend(AudioBackend::SoundCardSox, note) {
+                *backend_state = AudioBackendState::Active(AudioBackend::SoundCardSox);
+                Some(child)
+            } else {
+                *backend_state = AudioBackendState::Unavailable;
+                None
             }
         }
-
-        if let Some(notes) = queued_sfx.pop_front() {
-            play_notes(
-                notes,
-                settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT),
-                &mut pcspkr_availability,
-            );
-            continue;
+        AudioBackendState::Pending(backend) | AudioBackendState::Active(backend) => {
+            if let Some(child) = spawn_with_backend(backend, note) {
+                *backend_state = AudioBackendState::Active(backend);
+                Some(child)
+            } else {
+                *backend_state = AudioBackendState::Unavailable;
+                None
+            }
         }
-
-        if stop_requested {
-            break;
-        }
-
-        if settings.theme_enabled {
-            let theme = theme_notes(settings.theme_song);
-            let note = theme[theme_index % theme.len()];
-            theme_index += 1;
-            play_note(
-                note,
-                settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT),
-                &mut pcspkr_availability,
-            );
-        } else {
-            thread::sleep(Duration::from_millis(10));
-        }
+        AudioBackendState::Unavailable => None,
     }
 }
 
-fn play_notes(notes: &[Note], tempo_percent: u16, pcspkr_availability: &mut PcSpkrAvailability) {
-    for note in notes {
-        play_note(*note, tempo_percent, pcspkr_availability);
+fn spawn_with_backend(backend: AudioBackend, note: PlaybackNote) -> Option<Child> {
+    match backend {
+        AudioBackend::Auto => None,
+        AudioBackend::PcSpeakerBeep => Command::new("beep")
+            .arg("-f")
+            .arg(note.frequency_hz.to_string())
+            .arg("-l")
+            .arg(note.duration_ms.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok(),
+        AudioBackend::SoundCardSox => Command::new("sox")
+            .arg("-q")
+            .arg("-n")
+            .arg("-d")
+            .arg("synth")
+            .arg(format!("{:.3}", f64::from(note.duration_ms) / 1000.0))
+            .arg("sine")
+            .arg(note.frequency_hz.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok(),
     }
 }
 
-fn play_note(note: Note, tempo_percent: u16, pcspkr_availability: &mut PcSpkrAvailability) {
-    let scaled_duration_ms = (u32::from(note.duration_ms) * 100)
+fn scale_note(note: Note, tempo_percent: u16) -> PlaybackNote {
+    let duration_ms = (u32::from(note.duration_ms) * 100)
         .checked_div(u32::from(tempo_percent))
         .unwrap_or(u32::from(note.duration_ms))
         .clamp(1, 10_000);
-    let scaled_rest_ms = (u32::from(note.rest_ms) * 100)
+    let rest_ms = (u32::from(note.rest_ms) * 100)
         .checked_div(u32::from(tempo_percent))
         .unwrap_or(u32::from(note.rest_ms))
         .clamp(0, 10_000);
 
-    if note.frequency_hz == 0 {
-        thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
-    } else {
-        let beep_result = if matches!(pcspkr_availability, PcSpkrAvailability::Unavailable) {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "pcspkr/beep not available",
-            ))
-        } else {
-            Command::new("beep")
-                .arg("-f")
-                .arg(note.frequency_hz.to_string())
-                .arg("-l")
-                .arg(scaled_duration_ms.to_string())
-                .status()
-                .map(|_| ())
-        };
-
-        if let Err(err) = beep_result {
-            if matches!(
-                err.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
-            ) {
-                *pcspkr_availability = PcSpkrAvailability::Unavailable;
-            }
-            let _ = std::io::stdout().write_all(b"\x07");
-            let _ = std::io::stdout().flush();
-            thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
-        } else {
-            *pcspkr_availability = PcSpkrAvailability::Available;
-        }
-    }
-
-    if scaled_rest_ms > 0 {
-        thread::sleep(Duration::from_millis(u64::from(scaled_rest_ms)));
+    PlaybackNote {
+        frequency_hz: note.frequency_hz,
+        duration_ms,
+        rest_ms,
     }
 }
 
@@ -223,14 +374,11 @@ fn notes_for_sfx(effect: SoundEffect, settings: AudioSettings) -> &'static [Note
     }
 }
 
-fn theme_notes(song: ThemeSong) -> &'static [Note] {
-    match song {
-        ThemeSong::KorobeinikiA => &THEME_KOROBEINIKI_A,
-        ThemeSong::KorobeinikiB => &THEME_KOROBEINIKI_B,
-    }
+fn theme_notes(_settings: AudioSettings) -> &'static [Note] {
+    &THEME_KOROBEINIKI
 }
 
-const THEME_KOROBEINIKI_A: [Note; 32] = [
+const THEME_KOROBEINIKI: [Note; 38] = [
     n(659, 400, 12),
     n(494, 200, 12),
     n(523, 200, 12),
@@ -244,41 +392,6 @@ const THEME_KOROBEINIKI_A: [Note; 32] = [
     n(587, 200, 12),
     n(523, 200, 12),
     n(494, 600, 20),
-    n(523, 200, 12),
-    n(587, 400, 12),
-    n(659, 400, 12),
-    n(523, 400, 12),
-    n(440, 400, 12),
-    n(440, 400, 12),
-    n(0, 200, 15),
-    n(587, 400, 12),
-    n(698, 200, 12),
-    n(880, 400, 12),
-    n(784, 200, 12),
-    n(698, 200, 12),
-    n(659, 600, 15),
-    n(523, 200, 12),
-    n(659, 400, 12),
-    n(587, 200, 12),
-    n(523, 200, 12),
-    n(494, 600, 20),
-    n(0, 200, 15),
-];
-
-const THEME_KOROBEINIKI_B: [Note; 38] = [
-    n(659, 400, 12),
-    n(494, 200, 12),
-    n(523, 200, 12),
-    n(587, 400, 12),
-    n(523, 200, 12),
-    n(494, 200, 12),
-    n(440, 400, 12),
-    n(440, 200, 12),
-    n(523, 200, 12),
-    n(659, 400, 12),
-    n(587, 200, 12),
-    n(523, 200, 12),
-    n(494, 600, 12),
     n(523, 200, 12),
     n(587, 400, 12),
     n(659, 400, 12),
@@ -287,10 +400,10 @@ const THEME_KOROBEINIKI_B: [Note; 38] = [
     n(440, 800, 20),
     n(0, 200, 12),
     n(587, 400, 12),
-    n(740, 200, 12),
+    n(698, 200, 12),
     n(880, 400, 12),
     n(784, 200, 12),
-    n(740, 200, 12),
+    n(698, 200, 12),
     n(659, 600, 12),
     n(523, 200, 12),
     n(659, 400, 12),
@@ -355,3 +468,4 @@ const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {
 }
 
 const MIN_TEMPO_PERCENT: u16 = 20;
+const POLL_INTERVAL: Duration = Duration::from_millis(5);

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,11 +1,4 @@
-use std::{
-    collections::VecDeque,
-    io::Write,
-    process::Command,
-    sync::mpsc,
-    thread,
-    time::Duration,
-};
+use std::{collections::VecDeque, io::Write, process::Command, sync::mpsc, thread, time::Duration};
 
 use crate::{
     core_game_engine::{Notification, NotificationFeed},
@@ -30,6 +23,13 @@ struct Note {
 enum AudioCommand {
     PlaySfx(SoundEffect),
     Stop,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PcSpkrAvailability {
+    Unknown,
+    Available,
+    Unavailable,
 }
 
 pub struct AudioController {
@@ -70,7 +70,9 @@ impl AudioController {
                     self.send(AudioCommand::PlaySfx(SoundEffect::PieceLock));
                 }
                 Notification::Accolade { lineclears, .. } if self.settings.line_clear_sfx => {
-                    self.send(AudioCommand::PlaySfx(SoundEffect::LineClear { lines: *lineclears }));
+                    self.send(AudioCommand::PlaySfx(SoundEffect::LineClear {
+                        lines: *lineclears,
+                    }));
                 }
                 Notification::GameEnded { is_win: false, .. } if self.settings.game_over_sfx => {
                     self.send(AudioCommand::PlaySfx(SoundEffect::GameOver));
@@ -97,10 +99,13 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
     let mut queued_sfx: VecDeque<&'static [Note]> = VecDeque::new();
     let mut theme_index = 0usize;
     let mut stop = false;
+    let mut pcspkr_availability = PcSpkrAvailability::Unknown;
 
     while !stop {
         match receiver.recv_timeout(Duration::from_millis(5)) {
-            Ok(AudioCommand::PlaySfx(effect)) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+            Ok(AudioCommand::PlaySfx(effect)) => {
+                queued_sfx.push_back(notes_for_sfx(effect, settings))
+            }
             Ok(AudioCommand::Stop) => stop = true,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
@@ -108,7 +113,9 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
 
         while let Ok(command) = receiver.try_recv() {
             match command {
-                AudioCommand::PlaySfx(effect) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+                AudioCommand::PlaySfx(effect) => {
+                    queued_sfx.push_back(notes_for_sfx(effect, settings))
+                }
                 AudioCommand::Stop => {
                     stop = true;
                     break;
@@ -121,7 +128,11 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
         }
 
         if let Some(notes) = queued_sfx.pop_front() {
-            play_notes(notes, settings.theme_tempo_percent.max(20));
+            play_notes(
+                notes,
+                settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT),
+                &mut pcspkr_availability,
+            );
             continue;
         }
 
@@ -129,20 +140,24 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             let theme = theme_notes(settings.theme_song);
             let note = theme[theme_index % theme.len()];
             theme_index += 1;
-            play_note(note, settings.theme_tempo_percent.max(20));
+            play_note(
+                note,
+                settings.theme_tempo_percent.max(MIN_TEMPO_PERCENT),
+                &mut pcspkr_availability,
+            );
         } else {
             thread::sleep(Duration::from_millis(10));
         }
     }
 }
 
-fn play_notes(notes: &[Note], tempo_percent: u16) {
+fn play_notes(notes: &[Note], tempo_percent: u16, pcspkr_availability: &mut PcSpkrAvailability) {
     for note in notes {
-        play_note(*note, tempo_percent);
+        play_note(*note, tempo_percent, pcspkr_availability);
     }
 }
 
-fn play_note(note: Note, tempo_percent: u16) {
+fn play_note(note: Note, tempo_percent: u16, pcspkr_availability: &mut PcSpkrAvailability) {
     let scaled_duration_ms = (u32::from(note.duration_ms) * 100)
         .checked_div(u32::from(tempo_percent))
         .unwrap_or(u32::from(note.duration_ms))
@@ -155,17 +170,33 @@ fn play_note(note: Note, tempo_percent: u16) {
     if note.frequency_hz == 0 {
         thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
     } else {
-        let status = Command::new("beep")
-            .arg("-f")
-            .arg(note.frequency_hz.to_string())
-            .arg("-l")
-            .arg(scaled_duration_ms.to_string())
-            .status();
+        let beep_result = if matches!(pcspkr_availability, PcSpkrAvailability::Unavailable) {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "pcspkr/beep not available",
+            ))
+        } else {
+            Command::new("beep")
+                .arg("-f")
+                .arg(note.frequency_hz.to_string())
+                .arg("-l")
+                .arg(scaled_duration_ms.to_string())
+                .status()
+                .map(|_| ())
+        };
 
-        if status.is_err() {
+        if let Err(err) = beep_result {
+            if matches!(
+                err.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) {
+                *pcspkr_availability = PcSpkrAvailability::Unavailable;
+            }
             let _ = std::io::stdout().write_all(b"\x07");
             let _ = std::io::stdout().flush();
             thread::sleep(Duration::from_millis(u64::from(scaled_duration_ms)));
+        } else {
+            *pcspkr_availability = PcSpkrAvailability::Available;
         }
     }
 
@@ -283,12 +314,8 @@ const SFX_GAME_OVER_CLASSIC: [Note; 6] = [
 
 const SFX_KEYPRESS_ARCADE: [Note; 2] = [n(988, 18, 2), n(1175, 20, 3)];
 const SFX_PIECE_LOCK_ARCADE: [Note; 3] = [n(440, 22, 2), n(349, 24, 2), n(262, 45, 4)];
-const SFX_LINE_CLEAR_ARCADE: [Note; 4] = [
-    n(659, 35, 2),
-    n(784, 35, 2),
-    n(988, 35, 2),
-    n(1175, 70, 8),
-];
+const SFX_LINE_CLEAR_ARCADE: [Note; 4] =
+    [n(659, 35, 2), n(784, 35, 2), n(988, 35, 2), n(1175, 70, 8)];
 const SFX_LINE_CLEAR_TETRIS_ARCADE: [Note; 6] = [
     n(523, 32, 2),
     n(659, 32, 2),
@@ -313,3 +340,5 @@ const fn n(frequency_hz: u16, duration_ms: u16, rest_ms: u16) -> Note {
         rest_ms,
     }
 }
+
+const MIN_TEMPO_PERCENT: u16 = 20;

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -139,15 +139,18 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             break;
         }
 
-        if let Some(playback) = active_note.as_mut() {
-            if Instant::now() >= playback.deadline {
-                finish_active_note(&mut active_note);
-            }
+        if let Some(playback) = active_note.as_mut()
+            && Instant::now() >= playback.deadline
+        {
+            finish_active_note(&mut active_note);
         }
 
         if let Some(playback) = active_note.as_mut()
             && !queued_sfx.is_empty()
-            && matches!(playback.kind, PlaybackKind::Theme | PlaybackKind::ThemeResume)
+            && matches!(
+                playback.kind,
+                PlaybackKind::Theme | PlaybackKind::ThemeResume
+            )
         {
             let now = Instant::now();
             let remaining_duration_ms = playback
@@ -163,19 +166,22 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
                 .try_into()
                 .unwrap_or(u32::MAX);
 
-            theme_resume_note = (remaining_duration_ms > 0 || remaining_rest_ms > 0).then_some(
-                PlaybackNote {
+            theme_resume_note =
+                (remaining_duration_ms > 0 || remaining_rest_ms > 0).then_some(PlaybackNote {
                     frequency_hz: playback.note.frequency_hz,
                     duration_ms: remaining_duration_ms,
                     rest_ms: remaining_rest_ms,
-                },
-            );
+                });
             stop_active_note(&mut active_note);
         }
 
         if active_note.is_none() {
             if let Some(note) = theme_resume_note.take() {
-                active_note = Some(play_note(note, PlaybackKind::ThemeResume, &mut backend_state));
+                active_note = Some(play_note(
+                    note,
+                    PlaybackKind::ThemeResume,
+                    &mut backend_state,
+                ));
                 continue;
             }
 
@@ -216,7 +222,9 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
             .min(POLL_INTERVAL);
 
         match receiver.recv_timeout(timeout) {
-            Ok(AudioCommand::PlaySfx(effect)) => queued_sfx.push_back(notes_for_sfx(effect, settings)),
+            Ok(AudioCommand::PlaySfx(effect)) => {
+                queued_sfx.push_back(notes_for_sfx(effect, settings))
+            }
             Ok(AudioCommand::Stop) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
             Err(mpsc::RecvTimeoutError::Timeout) => {}

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -98,15 +98,15 @@ impl Drop for AudioController {
 fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings) {
     let mut queued_sfx: VecDeque<&'static [Note]> = VecDeque::new();
     let mut theme_index = 0usize;
-    let mut stop = false;
+    let mut stop_requested = false;
     let mut pcspkr_availability = PcSpkrAvailability::Unknown;
 
-    while !stop {
+    loop {
         match receiver.recv_timeout(Duration::from_millis(5)) {
             Ok(AudioCommand::PlaySfx(effect)) => {
                 queued_sfx.push_back(notes_for_sfx(effect, settings))
             }
-            Ok(AudioCommand::Stop) => stop = true,
+            Ok(AudioCommand::Stop) => stop_requested = true,
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
             Err(mpsc::RecvTimeoutError::Timeout) => {}
         }
@@ -117,14 +117,9 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
                     queued_sfx.push_back(notes_for_sfx(effect, settings))
                 }
                 AudioCommand::Stop => {
-                    stop = true;
-                    break;
+                    stop_requested = true;
                 }
             }
-        }
-
-        if stop {
-            break;
         }
 
         if let Some(notes) = queued_sfx.pop_front() {
@@ -134,6 +129,10 @@ fn audio_worker(receiver: mpsc::Receiver<AudioCommand>, settings: AudioSettings)
                 &mut pcspkr_availability,
             );
             continue;
+        }
+
+        if stop_requested {
+            break;
         }
 
         if settings.theme_enabled {
@@ -232,65 +231,79 @@ fn theme_notes(song: ThemeSong) -> &'static [Note] {
 }
 
 const THEME_KOROBEINIKI_A: [Note; 32] = [
-    n(659, 125, 10),
-    n(494, 63, 10),
-    n(523, 63, 10),
-    n(587, 125, 10),
-    n(523, 63, 10),
-    n(494, 63, 10),
-    n(440, 125, 10),
-    n(440, 63, 10),
-    n(523, 63, 10),
-    n(659, 125, 10),
-    n(587, 63, 10),
-    n(523, 63, 10),
-    n(494, 188, 20),
-    n(523, 63, 10),
-    n(587, 125, 10),
-    n(659, 125, 10),
-    n(523, 125, 10),
-    n(440, 125, 10),
-    n(440, 125, 10),
-    n(0, 63, 15),
-    n(587, 125, 10),
-    n(698, 63, 10),
-    n(880, 125, 10),
-    n(784, 63, 10),
-    n(698, 63, 10),
-    n(659, 188, 15),
-    n(523, 63, 10),
-    n(659, 125, 10),
-    n(587, 63, 10),
-    n(523, 63, 10),
-    n(494, 188, 20),
-    n(0, 63, 15),
+    n(659, 400, 12),
+    n(494, 200, 12),
+    n(523, 200, 12),
+    n(587, 400, 12),
+    n(523, 200, 12),
+    n(494, 200, 12),
+    n(440, 400, 12),
+    n(440, 200, 12),
+    n(523, 200, 12),
+    n(659, 400, 12),
+    n(587, 200, 12),
+    n(523, 200, 12),
+    n(494, 600, 20),
+    n(523, 200, 12),
+    n(587, 400, 12),
+    n(659, 400, 12),
+    n(523, 400, 12),
+    n(440, 400, 12),
+    n(440, 400, 12),
+    n(0, 200, 15),
+    n(587, 400, 12),
+    n(698, 200, 12),
+    n(880, 400, 12),
+    n(784, 200, 12),
+    n(698, 200, 12),
+    n(659, 600, 15),
+    n(523, 200, 12),
+    n(659, 400, 12),
+    n(587, 200, 12),
+    n(523, 200, 12),
+    n(494, 600, 20),
+    n(0, 200, 15),
 ];
 
-const THEME_KOROBEINIKI_B: [Note; 24] = [
-    n(659, 150, 8),
-    n(523, 75, 8),
-    n(587, 75, 8),
-    n(659, 150, 8),
-    n(587, 75, 8),
-    n(523, 75, 8),
-    n(494, 150, 8),
-    n(494, 75, 8),
-    n(587, 75, 8),
-    n(698, 150, 8),
-    n(659, 75, 8),
-    n(587, 75, 8),
-    n(523, 150, 8),
-    n(523, 75, 8),
-    n(587, 75, 8),
-    n(659, 150, 8),
-    n(698, 75, 8),
-    n(784, 75, 8),
-    n(880, 225, 18),
-    n(784, 75, 8),
-    n(698, 75, 8),
-    n(659, 150, 8),
-    n(587, 150, 8),
-    n(0, 75, 20),
+const THEME_KOROBEINIKI_B: [Note; 38] = [
+    n(659, 400, 12),
+    n(494, 200, 12),
+    n(523, 200, 12),
+    n(587, 400, 12),
+    n(523, 200, 12),
+    n(494, 200, 12),
+    n(440, 400, 12),
+    n(440, 200, 12),
+    n(523, 200, 12),
+    n(659, 400, 12),
+    n(587, 200, 12),
+    n(523, 200, 12),
+    n(494, 600, 12),
+    n(523, 200, 12),
+    n(587, 400, 12),
+    n(659, 400, 12),
+    n(523, 400, 12),
+    n(440, 400, 12),
+    n(440, 800, 20),
+    n(0, 200, 12),
+    n(587, 400, 12),
+    n(740, 200, 12),
+    n(880, 400, 12),
+    n(784, 200, 12),
+    n(740, 200, 12),
+    n(659, 600, 12),
+    n(523, 200, 12),
+    n(659, 400, 12),
+    n(587, 200, 12),
+    n(523, 200, 12),
+    n(494, 400, 12),
+    n(494, 200, 12),
+    n(523, 200, 12),
+    n(587, 400, 12),
+    n(659, 400, 12),
+    n(523, 400, 12),
+    n(440, 400, 12),
+    n(440, 800, 20),
 ];
 
 const SFX_KEYPRESS_CLASSIC: [Note; 1] = [n(880, 22, 3)];

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod audio;
 mod core_game_engine;
 mod fmt_helpers;
 mod game_modding;
@@ -651,6 +652,7 @@ impl<W: Write> Application<W> {
                 ),
                 Menu::Pause => self.run_menu_pause(),
                 Menu::Settings => self.run_menu_settings(),
+                Menu::AdjustAudio => self.run_menu_adjust_audio(),
                 Menu::AdjustGraphics => self.run_menu_adjust_graphics(),
                 Menu::AdjustKeybinds => self.run_menu_adjust_keybinds(),
                 Menu::AdjustGameplay => self.run_menu_adjust_gameplay(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Console prologue: Initialization.
     // FIXME: Handle io::Error? If not, why not?
     let _e = app.initialize_terminal_state();
+    audio::AudioController::play_welcome_melody(app.settings.audio);
 
     // Run main application.
     let app_result = app.run();

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -1,3 +1,5 @@
+use std::process::{Command, Stdio};
+
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
 )]
@@ -34,7 +36,7 @@ pub struct AudioSettings {
 impl Default for AudioSettings {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: beep_is_available_in_path(),
             theme_enabled: true,
             sfx_enabled: true,
             theme_song: ThemeSong::KorobeinikiA,
@@ -46,4 +48,13 @@ impl Default for AudioSettings {
             game_over_sfx: true,
         }
     }
+}
+
+fn beep_is_available_in_path() -> bool {
+    Command::new("beep")
+        .arg("-h")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
 }

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -36,6 +36,7 @@ pub enum AudioBackend {
     #[default]
     Auto,
     PcSpeakerBeep,
+    SoundCardMidi,
     SoundCardSox,
 }
 
@@ -85,6 +86,7 @@ impl Default for AudioSettings {
 
 fn any_audio_backend_is_available() -> bool {
     audio_backend_is_available(AudioBackend::PcSpeakerBeep)
+        || audio_backend_is_available(AudioBackend::SoundCardMidi)
         || audio_backend_is_available(AudioBackend::SoundCardSox)
 }
 
@@ -92,6 +94,7 @@ pub fn audio_backend_is_available(backend: AudioBackend) -> bool {
     match backend {
         AudioBackend::Auto => any_audio_backend_is_available(),
         AudioBackend::PcSpeakerBeep => command_is_available("beep", "-h"),
+        AudioBackend::SoundCardMidi => command_is_available("timidity", "--help"),
         AudioBackend::SoundCardSox => command_is_available("sox", "--help"),
     }
 }

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -2,10 +2,27 @@ use std::process::{Command, Stdio};
 
 #[derive(
     PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+    Default,
 )]
 pub enum ThemeSong {
-    KorobeinikiA,
-    KorobeinikiB,
+    #[default]
+    #[serde(alias = "KorobeinikiA", alias = "KorobeinikiB")]
+    Korobeiniki,
+}
+
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+)]
+pub enum AudioBackend {
+    Auto,
+    PcSpeakerBeep,
+    SoundCardSox,
+}
+
+impl Default for AudioBackend {
+    fn default() -> Self {
+        Self::Auto
+    }
 }
 
 #[derive(
@@ -25,6 +42,7 @@ pub struct AudioSettings {
     pub theme_enabled: bool,
     pub sfx_enabled: bool,
     pub theme_song: ThemeSong,
+    pub backend: AudioBackend,
     pub sfx_pack: SfxPack,
     pub theme_tempo_percent: u16,
     pub keypress_sfx: bool,
@@ -36,10 +54,11 @@ pub struct AudioSettings {
 impl Default for AudioSettings {
     fn default() -> Self {
         Self {
-            enabled: beep_is_available_in_path(),
+            enabled: any_audio_backend_is_available(),
             theme_enabled: true,
             sfx_enabled: true,
-            theme_song: ThemeSong::KorobeinikiA,
+            theme_song: ThemeSong::Korobeiniki,
+            backend: AudioBackend::Auto,
             sfx_pack: SfxPack::Classic,
             theme_tempo_percent: 100,
             keypress_sfx: true,
@@ -50,9 +69,22 @@ impl Default for AudioSettings {
     }
 }
 
-fn beep_is_available_in_path() -> bool {
-    Command::new("beep")
-        .arg("-h")
+fn any_audio_backend_is_available() -> bool {
+    audio_backend_is_available(AudioBackend::PcSpeakerBeep)
+        || audio_backend_is_available(AudioBackend::SoundCardSox)
+}
+
+pub fn audio_backend_is_available(backend: AudioBackend) -> bool {
+    match backend {
+        AudioBackend::Auto => any_audio_backend_is_available(),
+        AudioBackend::PcSpeakerBeep => command_is_available("beep", "-h"),
+        AudioBackend::SoundCardSox => command_is_available("sox", "--help"),
+    }
+}
+
+fn command_is_available(command: &str, probe_arg: &str) -> bool {
+    Command::new(command)
+        .arg(probe_arg)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -36,7 +36,6 @@ pub enum AudioBackend {
     #[default]
     Auto,
     PcSpeakerBeep,
-    SoundCardMidi,
     SoundCardSox,
 }
 
@@ -86,7 +85,6 @@ impl Default for AudioSettings {
 
 fn any_audio_backend_is_available() -> bool {
     audio_backend_is_available(AudioBackend::PcSpeakerBeep)
-        || audio_backend_is_available(AudioBackend::SoundCardMidi)
         || audio_backend_is_available(AudioBackend::SoundCardSox)
 }
 
@@ -94,7 +92,6 @@ pub fn audio_backend_is_available(backend: AudioBackend) -> bool {
     match backend {
         AudioBackend::Auto => any_audio_backend_is_available(),
         AudioBackend::PcSpeakerBeep => command_is_available("beep", "-h"),
-        AudioBackend::SoundCardMidi => command_is_available("timidity", "--help"),
         AudioBackend::SoundCardSox => command_is_available("sox", "--help"),
     }
 }

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -1,0 +1,49 @@
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+)]
+pub enum ThemeSong {
+    KorobeinikiA,
+    KorobeinikiB,
+}
+
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+)]
+pub enum SfxPack {
+    Classic,
+    Arcade,
+}
+
+#[derive(
+    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+)]
+#[serde(default)]
+pub struct AudioSettings {
+    pub enabled: bool,
+    pub theme_enabled: bool,
+    pub sfx_enabled: bool,
+    pub theme_song: ThemeSong,
+    pub sfx_pack: SfxPack,
+    pub theme_tempo_percent: u16,
+    pub keypress_sfx: bool,
+    pub piece_lock_sfx: bool,
+    pub line_clear_sfx: bool,
+    pub game_over_sfx: bool,
+}
+
+impl Default for AudioSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            theme_enabled: true,
+            sfx_enabled: true,
+            theme_song: ThemeSong::KorobeinikiA,
+            sfx_pack: SfxPack::Classic,
+            theme_tempo_percent: 100,
+            keypress_sfx: true,
+            piece_lock_sfx: true,
+            line_clear_sfx: true,
+            game_over_sfx: true,
+        }
+    }
+}

--- a/src/settings/audio_settings.rs
+++ b/src/settings/audio_settings.rs
@@ -1,7 +1,16 @@
 use std::process::{Command, Stdio};
 
 #[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
     Default,
 )]
 pub enum ThemeSong {
@@ -11,18 +20,23 @@ pub enum ThemeSong {
 }
 
 #[derive(
-    PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, serde::Serialize, serde::Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Debug,
+    serde::Serialize,
+    serde::Deserialize,
+    Default,
 )]
 pub enum AudioBackend {
+    #[default]
     Auto,
     PcSpeakerBeep,
     SoundCardSox,
-}
-
-impl Default for AudioBackend {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 #[derive(

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,8 +1,10 @@
+mod audio_settings;
 mod game_keybinds;
 mod game_mode_settings;
 mod gameplay_preferences;
 mod graphics_settings;
 
+pub use audio_settings::{AudioSettings, SfxPack, ThemeSong};
 pub use game_keybinds::GameKeybinds;
 pub use game_mode_settings::{CustomModeConfig, GameModeSettings};
 pub use gameplay_preferences::GameplayPreferences;
@@ -68,6 +70,9 @@ pub struct Settings {
     #[serde(rename = "GAMEPLAY_PREFERENCES_SLOTS")]
     pub gameplay_slotmachine: SlotMachine<GameplayPreferences>,
 
+    #[serde(default)]
+    pub audio: AudioSettings,
+
     #[serde(rename = "GAME_MODE_SETTINGS")]
     pub game_mode_preferences: GameModeSettings,
 }
@@ -92,6 +97,8 @@ impl Default for Settings {
 
             gameplay_selected: 0,
             gameplay_slotmachine: gameplay_settings_presets(),
+
+            audio: AudioSettings::default(),
 
             game_mode_preferences: GameModeSettings::default(),
         }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -4,7 +4,7 @@ mod game_mode_settings;
 mod gameplay_preferences;
 mod graphics_settings;
 
-pub use audio_settings::{AudioSettings, SfxPack, ThemeSong};
+pub use audio_settings::{AudioBackend, AudioSettings, SfxPack, ThemeSong, audio_backend_is_available};
 pub use game_keybinds::GameKeybinds;
 pub use game_mode_settings::{CustomModeConfig, GameModeSettings};
 pub use gameplay_preferences::GameplayPreferences;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -4,7 +4,9 @@ mod game_mode_settings;
 mod gameplay_preferences;
 mod graphics_settings;
 
-pub use audio_settings::{AudioBackend, AudioSettings, SfxPack, ThemeSong, audio_backend_is_available};
+pub use audio_settings::{
+    AudioBackend, AudioSettings, SfxPack, ThemeSong, audio_backend_is_available,
+};
 pub use game_keybinds::GameKeybinds;
 pub use game_mode_settings::{CustomModeConfig, GameModeSettings};
 pub use gameplay_preferences::GameplayPreferences;

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -231,8 +231,9 @@ fn fmt_theme_song(_song: crate::settings::ThemeSong) -> &'static str {
 
 fn fmt_audio_backend(backend: AudioBackend) -> &'static str {
     match backend {
-        AudioBackend::Auto => "Auto (beep -> sox)",
+        AudioBackend::Auto => "Auto (beep -> midi -> sox)",
         AudioBackend::PcSpeakerBeep => "PC speaker (beep)",
+        AudioBackend::SoundCardMidi => "Sound card (MIDI / timidity)",
         AudioBackend::SoundCardSox => "Sound card (sox)",
     }
 }
@@ -252,7 +253,10 @@ fn adjust_audio(settings: &mut crate::settings::AudioSettings, selected: usize, 
                 (AudioBackend::Auto, true) | (AudioBackend::PcSpeakerBeep, false) => {
                     AudioBackend::PcSpeakerBeep
                 }
-                (AudioBackend::PcSpeakerBeep, true) | (AudioBackend::SoundCardSox, false) => {
+                (AudioBackend::PcSpeakerBeep, true) | (AudioBackend::SoundCardMidi, false) => {
+                    AudioBackend::SoundCardMidi
+                }
+                (AudioBackend::SoundCardMidi, true) | (AudioBackend::SoundCardSox, false) => {
                     AudioBackend::SoundCardSox
                 }
                 (AudioBackend::SoundCardSox, true) | (AudioBackend::Auto, false) => {

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -55,17 +55,35 @@ impl<W: Write> Application<W> {
                     "Theme (BGM) enabled = {}",
                     on_off(self.settings.audio.theme_enabled)
                 ),
-                format!("Sound effects enabled = {}", on_off(self.settings.audio.sfx_enabled)),
-                format!("Theme song = {}", fmt_theme_song(self.settings.audio.theme_song)),
+                format!(
+                    "Sound effects enabled = {}",
+                    on_off(self.settings.audio.sfx_enabled)
+                ),
+                format!(
+                    "Theme song = {}",
+                    fmt_theme_song(self.settings.audio.theme_song)
+                ),
                 format!(
                     "Theme tempo = {}%",
                     self.settings.audio.theme_tempo_percent.clamp(20, 250)
                 ),
                 format!("SFX pack = {}", fmt_sfx_pack(self.settings.audio.sfx_pack)),
-                format!("Keypress SFX = {}", on_off(self.settings.audio.keypress_sfx)),
-                format!("Piece lock SFX = {}", on_off(self.settings.audio.piece_lock_sfx)),
-                format!("Line clear SFX = {}", on_off(self.settings.audio.line_clear_sfx)),
-                format!("Game over SFX = {}", on_off(self.settings.audio.game_over_sfx)),
+                format!(
+                    "Keypress SFX = {}",
+                    on_off(self.settings.audio.keypress_sfx)
+                ),
+                format!(
+                    "Piece lock SFX = {}",
+                    on_off(self.settings.audio.piece_lock_sfx)
+                ),
+                format!(
+                    "Line clear SFX = {}",
+                    on_off(self.settings.audio.line_clear_sfx)
+                ),
+                format!(
+                    "Game over SFX = {}",
+                    on_off(self.settings.audio.game_over_sfx)
+                ),
             ];
 
             let selection_len = labels.len();
@@ -157,15 +175,21 @@ impl<W: Write> Application<W> {
 
                 Event::Key(KeyEvent {
                     code: KeyCode::Right | KeyCode::Char('l' | 'L'),
+                    modifiers,
                     kind: Press | Repeat,
                     ..
-                }) => adjust_audio(&mut self.settings.audio, selected, true),
+                }) if !modifiers.contains(KeyModifiers::CONTROL.union(KeyModifiers::ALT)) => {
+                    adjust_audio(&mut self.settings.audio, selected, true)
+                }
 
                 Event::Key(KeyEvent {
                     code: KeyCode::Left | KeyCode::Char('h' | 'H'),
+                    modifiers,
                     kind: Press | Repeat,
                     ..
-                }) => adjust_audio(&mut self.settings.audio, selected, false),
+                }) if !modifiers.contains(KeyModifiers::CONTROL.union(KeyModifiers::ALT)) => {
+                    adjust_audio(&mut self.settings.audio, selected, false)
+                }
 
                 Event::Key(KeyEvent {
                     code: KeyCode::Char('l' | 'L'),

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -281,3 +281,11 @@ fn adjust_audio(settings: &mut crate::settings::AudioSettings, selected: usize, 
         _ => {}
     }
 }
+
+fn backend_status_suffix(backend: AudioBackend) -> &'static str {
+    if audio_backend_is_available(backend) {
+        ""
+    } else {
+        " [missing]"
+    }
+}

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -1,0 +1,245 @@
+use std::io::{self, Write};
+
+use crossterm::{
+    QueueableCommand,
+    cursor::MoveTo,
+    event::{
+        self, Event, KeyCode, KeyEvent,
+        KeyEventKind::{Press, Repeat},
+        KeyModifiers,
+    },
+    style::{Color, PrintStyledContent, Stylize},
+    terminal::{self, Clear, ClearType},
+};
+
+use crate::{
+    Application,
+    settings::{SfxPack, ThemeSong},
+    tui_menus::{Menu, MenuUpdate, heading_line},
+};
+
+impl<W: Write> Application<W> {
+    pub fn run_menu_adjust_audio(&mut self) -> io::Result<MenuUpdate> {
+        let mut selected = 0usize;
+        loop {
+            if self.settings.tui_coloring().bg_tui == Color::Reset {
+                self.term.queue(Clear(ClearType::All))?;
+            } else {
+                self.term.queue(MoveTo(0, 0))?.queue(PrintStyledContent({
+                    let (w, h) = terminal::size()?;
+                    " ".repeat(w as usize * h as usize)
+                        .on(self.settings.tui_coloring().bg_tui)
+                }))?;
+            }
+            let w_main = Self::W_MAIN.into();
+            let (x_main, y_main) = Self::viewport_offset();
+            let y_selection = (Self::H_MAIN / 5).saturating_sub(1);
+            self.term
+                .queue(MoveTo(x_main, y_main + y_selection))?
+                .queue(PrintStyledContent(
+                    format!("{:^w_main$}", "= Audio Settings =")
+                        .bold()
+                        .with(self.settings.tui_coloring().fg_tui)
+                        .on(self.settings.tui_coloring().bg_tui),
+                ))?
+                .queue(MoveTo(x_main, y_main + y_selection + 2))?
+                .queue(PrintStyledContent(
+                    format!("{:^w_main$}", heading_line(&self.settings))
+                        .with(self.settings.tui_coloring().fg_accent)
+                        .on(self.settings.tui_coloring().bg_tui),
+                ))?;
+
+            let labels = [
+                format!("Audio enabled = {}", on_off(self.settings.audio.enabled)),
+                format!(
+                    "Theme (BGM) enabled = {}",
+                    on_off(self.settings.audio.theme_enabled)
+                ),
+                format!("Sound effects enabled = {}", on_off(self.settings.audio.sfx_enabled)),
+                format!("Theme song = {}", fmt_theme_song(self.settings.audio.theme_song)),
+                format!(
+                    "Theme tempo = {}%",
+                    self.settings.audio.theme_tempo_percent.clamp(20, 250)
+                ),
+                format!("SFX pack = {}", fmt_sfx_pack(self.settings.audio.sfx_pack)),
+                format!("Keypress SFX = {}", on_off(self.settings.audio.keypress_sfx)),
+                format!("Piece lock SFX = {}", on_off(self.settings.audio.piece_lock_sfx)),
+                format!("Line clear SFX = {}", on_off(self.settings.audio.line_clear_sfx)),
+                format!("Game over SFX = {}", on_off(self.settings.audio.game_over_sfx)),
+            ];
+
+            let selection_len = labels.len();
+            for (i, label) in labels.into_iter().enumerate() {
+                self.term
+                    .queue(MoveTo(
+                        x_main,
+                        y_main + y_selection + 4 + u16::try_from(i).unwrap(),
+                    ))?
+                    .queue(PrintStyledContent(
+                        format!(
+                            "{:^w_main$}",
+                            if i == selected {
+                                format!(
+                                    "{} {label} {}",
+                                    self.settings.tui_symbols().menu_pointers[0],
+                                    self.settings.tui_symbols().menu_pointers[1]
+                                )
+                            } else {
+                                label
+                            }
+                        )
+                        .with(self.settings.tui_coloring().fg_tui)
+                        .on(self.settings.tui_coloring().bg_tui),
+                    ))?;
+            }
+
+            self.term.flush()?;
+
+            match event::read()? {
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('c' | 'C'),
+                    modifiers: KeyModifiers::CONTROL,
+                    kind: Press | Repeat,
+                    ..
+                }) => break Ok(MenuUpdate::Push(Menu::Quit)),
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('?'),
+                    kind: Press | Repeat,
+                    ..
+                }) => {
+                    let client_menu_name = "Audio Settings menu";
+                    let legend = vec![(
+                        "Normal keybinds".to_owned(),
+                        [
+                            ("Escape Backspace q", "Exit menu"),
+                            ("Delete d", "Reset audio settings"),
+                            ("↓/↑ j/k", "Navigate down/up"),
+                            ("←/→ h/l", "Adjust value"),
+                            ("?", "Open Keybinds overview"),
+                        ]
+                        .into_iter()
+                        .map(|(lhs, rhs)| (lhs.to_owned(), rhs.to_owned()))
+                        .collect(),
+                    )];
+
+                    break Ok(MenuUpdate::Push(Menu::KeybindsOverview {
+                        client_menu_name,
+                        legend,
+                    }));
+                }
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Esc | KeyCode::Char('q' | 'Q') | KeyCode::Backspace,
+                    kind: Press,
+                    ..
+                }) => break Ok(MenuUpdate::Pop),
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Up | KeyCode::Char('k' | 'K'),
+                    kind: Press | Repeat,
+                    ..
+                }) => selected += selection_len - 1,
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Down | KeyCode::Char('j' | 'J'),
+                    kind: Press | Repeat,
+                    ..
+                }) => selected += 1,
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Delete | KeyCode::Char('d' | 'D'),
+                    kind: Press | Repeat,
+                    ..
+                }) => {
+                    self.settings.audio = Default::default();
+                }
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Right | KeyCode::Char('l' | 'L'),
+                    kind: Press | Repeat,
+                    ..
+                }) => adjust_audio(&mut self.settings.audio, selected, true),
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Left | KeyCode::Char('h' | 'H'),
+                    kind: Press | Repeat,
+                    ..
+                }) => adjust_audio(&mut self.settings.audio, selected, false),
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('l' | 'L'),
+                    modifiers,
+                    kind: Press | Repeat,
+                    ..
+                }) if { modifiers.contains(KeyModifiers::CONTROL.union(KeyModifiers::ALT)) } => {
+                    self.temp_data.load_savefile_result = self.savefile_read();
+                }
+
+                Event::Key(KeyEvent {
+                    code: KeyCode::Char('s' | 'S'),
+                    modifiers,
+                    kind: Press | Repeat,
+                    ..
+                }) if { modifiers.contains(KeyModifiers::CONTROL.union(KeyModifiers::ALT)) } => {
+                    self.temp_data.store_savefile_result = self.savefile_write();
+                }
+
+                _ => {}
+            }
+            selected = selected.rem_euclid(selection_len);
+        }
+    }
+}
+
+fn on_off(flag: bool) -> &'static str {
+    if flag { "On" } else { "Off" }
+}
+
+fn fmt_theme_song(song: ThemeSong) -> &'static str {
+    match song {
+        ThemeSong::KorobeinikiA => "Korobeiniki A",
+        ThemeSong::KorobeinikiB => "Korobeiniki B",
+    }
+}
+
+fn fmt_sfx_pack(pack: SfxPack) -> &'static str {
+    match pack {
+        SfxPack::Classic => "Classic",
+        SfxPack::Arcade => "Arcade",
+    }
+}
+
+fn adjust_audio(settings: &mut crate::settings::AudioSettings, selected: usize, increase: bool) {
+    match selected {
+        0 => settings.enabled ^= true,
+        1 => settings.theme_enabled ^= true,
+        2 => settings.sfx_enabled ^= true,
+        3 => {
+            settings.theme_song = match (settings.theme_song, increase) {
+                (ThemeSong::KorobeinikiA, true) | (ThemeSong::KorobeinikiB, false) => {
+                    ThemeSong::KorobeinikiB
+                }
+                (ThemeSong::KorobeinikiB, true) | (ThemeSong::KorobeinikiA, false) => {
+                    ThemeSong::KorobeinikiA
+                }
+            };
+        }
+        4 => {
+            let delta = if increase { 5 } else { -5 };
+            settings.theme_tempo_percent =
+                (i32::from(settings.theme_tempo_percent) + delta).clamp(20, 250) as u16;
+        }
+        5 => {
+            settings.sfx_pack = match (settings.sfx_pack, increase) {
+                (SfxPack::Classic, true) | (SfxPack::Arcade, false) => SfxPack::Arcade,
+                (SfxPack::Arcade, true) | (SfxPack::Classic, false) => SfxPack::Classic,
+            };
+        }
+        6 => settings.keypress_sfx ^= true,
+        7 => settings.piece_lock_sfx ^= true,
+        8 => settings.line_clear_sfx ^= true,
+        9 => settings.game_over_sfx ^= true,
+        _ => {}
+    }
+}

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -14,7 +14,7 @@ use crossterm::{
 
 use crate::{
     Application,
-    settings::{SfxPack, ThemeSong},
+    settings::{AudioBackend, SfxPack, audio_backend_is_available},
     tui_menus::{Menu, MenuUpdate, heading_line},
 };
 
@@ -51,6 +51,11 @@ impl<W: Write> Application<W> {
 
             let labels = [
                 format!("Audio enabled = {}", on_off(self.settings.audio.enabled)),
+                format!(
+                    "Audio output = {}{}",
+                    fmt_audio_backend(self.settings.audio.backend),
+                    backend_status_suffix(self.settings.audio.backend)
+                ),
                 format!(
                     "Theme (BGM) enabled = {}",
                     on_off(self.settings.audio.theme_enabled)
@@ -220,10 +225,15 @@ fn on_off(flag: bool) -> &'static str {
     if flag { "On" } else { "Off" }
 }
 
-fn fmt_theme_song(song: ThemeSong) -> &'static str {
-    match song {
-        ThemeSong::KorobeinikiA => "Korobeiniki A",
-        ThemeSong::KorobeinikiB => "Korobeiniki B",
+fn fmt_theme_song(_song: crate::settings::ThemeSong) -> &'static str {
+    "Korobeiniki"
+}
+
+fn fmt_audio_backend(backend: AudioBackend) -> &'static str {
+    match backend {
+        AudioBackend::Auto => "Auto (beep -> sox)",
+        AudioBackend::PcSpeakerBeep => "PC speaker (beep)",
+        AudioBackend::SoundCardSox => "Sound card (sox)",
     }
 }
 
@@ -237,33 +247,37 @@ fn fmt_sfx_pack(pack: SfxPack) -> &'static str {
 fn adjust_audio(settings: &mut crate::settings::AudioSettings, selected: usize, increase: bool) {
     match selected {
         0 => settings.enabled ^= true,
-        1 => settings.theme_enabled ^= true,
-        2 => settings.sfx_enabled ^= true,
-        3 => {
-            settings.theme_song = match (settings.theme_song, increase) {
-                (ThemeSong::KorobeinikiA, true) | (ThemeSong::KorobeinikiB, false) => {
-                    ThemeSong::KorobeinikiB
+        1 => {
+            settings.backend = match (settings.backend, increase) {
+                (AudioBackend::Auto, true) | (AudioBackend::PcSpeakerBeep, false) => {
+                    AudioBackend::PcSpeakerBeep
                 }
-                (ThemeSong::KorobeinikiB, true) | (ThemeSong::KorobeinikiA, false) => {
-                    ThemeSong::KorobeinikiA
+                (AudioBackend::PcSpeakerBeep, true) | (AudioBackend::SoundCardSox, false) => {
+                    AudioBackend::SoundCardSox
+                }
+                (AudioBackend::SoundCardSox, true) | (AudioBackend::Auto, false) => {
+                    AudioBackend::Auto
                 }
             };
         }
-        4 => {
+        2 => settings.theme_enabled ^= true,
+        3 => settings.sfx_enabled ^= true,
+        4 => {}
+        5 => {
             let delta = if increase { 5 } else { -5 };
             settings.theme_tempo_percent =
                 (i32::from(settings.theme_tempo_percent) + delta).clamp(20, 250) as u16;
         }
-        5 => {
+        6 => {
             settings.sfx_pack = match (settings.sfx_pack, increase) {
                 (SfxPack::Classic, true) | (SfxPack::Arcade, false) => SfxPack::Arcade,
                 (SfxPack::Arcade, true) | (SfxPack::Classic, false) => SfxPack::Classic,
             };
         }
-        6 => settings.keypress_sfx ^= true,
-        7 => settings.piece_lock_sfx ^= true,
-        8 => settings.line_clear_sfx ^= true,
-        9 => settings.game_over_sfx ^= true,
+        7 => settings.keypress_sfx ^= true,
+        8 => settings.piece_lock_sfx ^= true,
+        9 => settings.line_clear_sfx ^= true,
+        10 => settings.game_over_sfx ^= true,
         _ => {}
     }
 }

--- a/src/tui_menus/adjust_audio.rs
+++ b/src/tui_menus/adjust_audio.rs
@@ -231,9 +231,8 @@ fn fmt_theme_song(_song: crate::settings::ThemeSong) -> &'static str {
 
 fn fmt_audio_backend(backend: AudioBackend) -> &'static str {
     match backend {
-        AudioBackend::Auto => "Auto (beep -> midi -> sox)",
+        AudioBackend::Auto => "Auto (beep -> sox)",
         AudioBackend::PcSpeakerBeep => "PC speaker (beep)",
-        AudioBackend::SoundCardMidi => "Sound card (MIDI / timidity)",
         AudioBackend::SoundCardSox => "Sound card (sox)",
     }
 }
@@ -253,10 +252,7 @@ fn adjust_audio(settings: &mut crate::settings::AudioSettings, selected: usize, 
                 (AudioBackend::Auto, true) | (AudioBackend::PcSpeakerBeep, false) => {
                     AudioBackend::PcSpeakerBeep
                 }
-                (AudioBackend::PcSpeakerBeep, true) | (AudioBackend::SoundCardMidi, false) => {
-                    AudioBackend::SoundCardMidi
-                }
-                (AudioBackend::SoundCardMidi, true) | (AudioBackend::SoundCardSox, false) => {
+                (AudioBackend::PcSpeakerBeep, true) | (AudioBackend::SoundCardSox, false) => {
                     AudioBackend::SoundCardSox
                 }
                 (AudioBackend::SoundCardSox, true) | (AudioBackend::Auto, false) => {

--- a/src/tui_menus/mod.rs
+++ b/src/tui_menus/mod.rs
@@ -1,4 +1,5 @@
 pub mod about;
+pub mod adjust_audio;
 pub mod adjust_gameplay;
 pub mod adjust_graphics;
 pub mod adjust_keybinds;
@@ -58,6 +59,7 @@ pub enum Menu {
     },
     Pause,
     Settings,
+    AdjustAudio,
     AdjustGraphics,
     AdjustKeybinds,
     AdjustGameplay,
@@ -99,6 +101,7 @@ impl Menu {
             // }
             Menu::Pause => "Pause",
             Menu::Settings => "Settings",
+            Menu::AdjustAudio => "Adjust Audio",
             Menu::AdjustGraphics => "Adjust Graphics",
             Menu::AdjustKeybinds => "Adjust Keybinds",
             Menu::AdjustGameplay => "Adjust Gameplay",

--- a/src/tui_menus/play_game.rs
+++ b/src/tui_menus/play_game.rs
@@ -141,6 +141,10 @@ impl<W: Write> Application<W> {
             // Start new iteration of [render->input->] loop.
 
             if let Phase::GameEnd { cause, is_win } = game.phase() {
+                if !*is_win {
+                    audio_controller.stop_and_play_game_over();
+                }
+
                 self.statistics.games_ended += 1;
 
                 // Game ended, cannot actually continue playing;

--- a/src/tui_menus/play_game.rs
+++ b/src/tui_menus/play_game.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::{
+    audio::AudioController,
     core_game_engine::{Button, Game, GameEndCause, Input, Notification, Phase, UpdateGameError},
     fmt_helpers::calc_game_keybinds_legend,
     terminal_buffers::TermCell,
@@ -90,6 +91,7 @@ impl<W: Write> Application<W> {
         let _thread_handle = input_catcher::spawn(input_sender, is_stop_event);
 
         let mut temp_statistics = Statistics::default();
+        let audio_controller = AudioController::new(self.settings.audio);
 
         // FIXME: Might falsely lead to a teleport if the player pressed move within the time window at the beginning.
         // But we don't care much, as for 'usual' values this should not really happen.
@@ -290,10 +292,14 @@ impl<W: Write> Application<W> {
                         raw_input_history
                             .inputs
                             .push((update_target_time, player_input));
+                        if matches!(player_input, Input::Activate(_)) {
+                            audio_controller.play_keypress();
+                        }
 
                         match game.update(update_target_time, Some(player_input)) {
                             Ok(msgs) => {
                                 temp_statistics.accumulate_from_feed(&msgs);
+                                audio_controller.play_from_notifications(&msgs);
                                 game_renderer.update_feed(msgs, &self.settings)
                             }
                             Err(UpdateGameError::AlreadyEnded) => break 'wait,
@@ -336,10 +342,12 @@ impl<W: Write> Application<W> {
                         let input = Input::Activate(button);
 
                         raw_input_history.inputs.push((update_target_time, input));
+                        audio_controller.play_keypress();
 
                         match game.update(update_target_time, Some(input)) {
                             Ok(msgs) => {
                                 temp_statistics.accumulate_from_feed(&msgs);
+                                audio_controller.play_from_notifications(&msgs);
                                 game_renderer.update_feed(msgs, &self.settings);
                             }
                             Err(UpdateGameError::AlreadyEnded) => break 'wait,
@@ -356,6 +364,7 @@ impl<W: Write> Application<W> {
                         match update_result {
                             Ok(msgs) => {
                                 temp_statistics.accumulate_from_feed(&msgs);
+                                audio_controller.play_from_notifications(&msgs);
                                 game_renderer.update_feed(msgs, &self.settings)
                             }
                             Err(UpdateGameError::AlreadyEnded) => break 'wait,
@@ -467,6 +476,7 @@ impl<W: Write> Application<W> {
                                 match game.forfeit() {
                                     Ok(msgs) => {
                                         temp_statistics.accumulate_from_feed(&msgs);
+                                        audio_controller.play_from_notifications(&msgs);
                                         game_renderer.update_feed(msgs, &self.settings);
                                     }
 
@@ -773,6 +783,7 @@ impl<W: Write> Application<W> {
                 // Update.
                 Ok(msgs) => {
                     temp_statistics.accumulate_from_feed(&msgs);
+                    audio_controller.play_from_notifications(&msgs);
                     game_renderer.update_feed(msgs, &self.settings)
                 }
 

--- a/src/tui_menus/settings.rs
+++ b/src/tui_menus/settings.rs
@@ -70,6 +70,7 @@ impl<W: Write> Application<W> {
                         .grab(self.settings.gameplay_selected)
                         .0
                 ),
+                "Adjust audio ...".to_owned(),
                 format!(
                     "Keep save file: {}",
                     match self.temp_data.save_on_exit {
@@ -214,11 +215,12 @@ impl<W: Write> Application<W> {
                     0 => break Ok(MenuUpdate::Push(Menu::AdjustGraphics)),
                     1 => break Ok(MenuUpdate::Push(Menu::AdjustKeybinds)),
                     2 => break Ok(MenuUpdate::Push(Menu::AdjustGameplay)),
-                    3 => {
+                    3 => break Ok(MenuUpdate::Push(Menu::AdjustAudio)),
+                    4 => {
                         self.temp_data.save_on_exit =
                             SavefileGranularity::StoreSettingsScoresReplays;
                     }
-                    4 => break Ok(MenuUpdate::Push(Menu::AdvancedSettings)),
+                    5 => break Ok(MenuUpdate::Push(Menu::AdvancedSettings)),
                     _ => {}
                 },
 
@@ -284,7 +286,7 @@ impl<W: Write> Application<W> {
                             self.settings.gameplay_selected %=
                                 self.settings.gameplay_slotmachine.slots.len();
                         }
-                        3 => {
+                        4 => {
                             self.temp_data.save_on_exit = match self.temp_data.save_on_exit {
                                 SavefileGranularity::NoSavefile
                                 | SavefileGranularity::StoreSettingsScores
@@ -296,7 +298,8 @@ impl<W: Write> Application<W> {
                                 }
                             };
                         }
-                        4 => {}
+                        3 => {}
+                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }
@@ -326,7 +329,7 @@ impl<W: Write> Application<W> {
                             self.settings.gameplay_selected %=
                                 self.settings.gameplay_slotmachine.slots.len();
                         }
-                        3 => {
+                        4 => {
                             self.temp_data.save_on_exit = match self.temp_data.save_on_exit {
                                 SavefileGranularity::NoSavefile => {
                                     SavefileGranularity::StoreSettingsScoresReplays
@@ -338,7 +341,8 @@ impl<W: Write> Application<W> {
                                 }
                             };
                         }
-                        4 => {}
+                        3 => {}
+                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }
@@ -360,10 +364,11 @@ impl<W: Write> Application<W> {
                         2 => {
                             self.settings.gameplay_selected = 0;
                         }
-                        3 => {
+                        4 => {
                             self.temp_data.save_on_exit = SavefileGranularity::NoSavefile;
                         }
-                        4 => {}
+                        3 => {}
+                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }

--- a/src/tui_menus/settings.rs
+++ b/src/tui_menus/settings.rs
@@ -298,8 +298,6 @@ impl<W: Write> Application<W> {
                                 }
                             };
                         }
-                        3 => {}
-                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }
@@ -341,8 +339,6 @@ impl<W: Write> Application<W> {
                                 }
                             };
                         }
-                        3 => {}
-                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }
@@ -367,8 +363,6 @@ impl<W: Write> Application<W> {
                         4 => {
                             self.temp_data.save_on_exit = SavefileGranularity::NoSavefile;
                         }
-                        3 => {}
-                        5 => {}
                         // No accessible options beyond.
                         _ => {}
                     }


### PR DESCRIPTION
### Description
This PR adds the ability to play a background music as well as sound effects through the PC speaker (if present) by calling the `beep` package; as well as using `sox` to play using the sound card (available for laptops; etc)

There is now an "audio settings" option menu that can be used to toggle the audio engine on/off, or choose the playback method; as well as configuring the background music (currently only the Korobeiniki theme song, the classic official Tetris background music) and individual options to toggle the SFX and BGM.

This is mostly finished, but requires testing to be released.

Note: The `beep` and `sox` package has to be installed to be picked up. If not installed, the audio option will be turned off, so the change must be backwards compatible.

The `beep` package requires the `pcspkr` package to be loaded and not blocked.

Only Linux was tested but conceptually this should be compatible with Windows too, assuming proper calls exist.